### PR TITLE
Ensure heartbeat unittests do not rename the thread.

### DIFF
--- a/lib/core/heartbeat.cpp
+++ b/lib/core/heartbeat.cpp
@@ -60,9 +60,10 @@ namespace pstore {
     heartbeat::worker_thread::duration_type const heartbeat::worker_thread::max_time_ =
         duration_type::max ();
 
-    heartbeat::worker_thread::worker_thread ()
+    heartbeat::worker_thread::worker_thread (bool unittest)
             : sleep_time_ (&max_time_) {
-        threads::set_name ("heartbeat");
+        if (!unittest)
+            threads::set_name ("heartbeat");
     }
 
     void heartbeat::worker_thread::attach (heartbeat::key_type key, callback cb) {

--- a/lib/core/heartbeat.hpp
+++ b/lib/core/heartbeat.hpp
@@ -91,7 +91,7 @@ namespace pstore {
         /// \note This class is in the public interface to enable it to be unit tested.
         class worker_thread {
         public:
-            worker_thread ();
+            worker_thread (bool unittest=false);
             ~worker_thread () = default;
 
             // Move.

--- a/unittests/core/test_heartbeat.cpp
+++ b/unittests/core/test_heartbeat.cpp
@@ -58,26 +58,29 @@ namespace {
 
     class HeartbeatAttachDetach : public ::testing::Test {
     public:
-        void SetUp () final {}
-        void TearDown () final {}
+        void SetUp () final {
+            worker_ = new pstore::heartbeat::worker_thread (true);
+            assert (worker_);
+        }
+        void TearDown () final { delete worker_; }
 
     protected:
         void attach (int const * const v);
         void detach (int const * const v);
 
         mock_callback callback_;
-        pstore::heartbeat::worker_thread worker_;
+        pstore::heartbeat::worker_thread* worker_;
     };
 
     void HeartbeatAttachDetach::attach (int const * const v) {
         using namespace std::placeholders;
         auto const key = pstore::heartbeat::to_key_type (v);
-        worker_.attach (key, std::bind (&mock_callback::callback, &callback_, _1));
+        worker_->attach (key, std::bind (&mock_callback::callback, &callback_, _1));
     }
 
     void HeartbeatAttachDetach::detach (int const * const v) {
         auto const key = pstore::heartbeat::to_key_type (v);
-        worker_.detach (key);
+        worker_->detach (key);
     }
 } // namespace
 
@@ -85,7 +88,7 @@ TEST_F (HeartbeatAttachDetach, SingleAttach) {
     int dummy = 42;
     EXPECT_CALL (callback_, callback (pstore::heartbeat::to_key_type (&dummy))).Times (2);
     this->attach (&dummy);
-    worker_.step ();
+    worker_->step ();
 }
 
 TEST_F (HeartbeatAttachDetach, MultipleAttach) {
@@ -93,7 +96,7 @@ TEST_F (HeartbeatAttachDetach, MultipleAttach) {
     EXPECT_CALL (callback_, callback (pstore::heartbeat::to_key_type (&dummy))).Times (3);
     this->attach (&dummy);
     this->attach (&dummy);
-    worker_.step ();
+    worker_->step ();
 }
 
 TEST_F (HeartbeatAttachDetach, SingleAttachDetach) {
@@ -101,7 +104,7 @@ TEST_F (HeartbeatAttachDetach, SingleAttachDetach) {
     EXPECT_CALL (callback_, callback (pstore::heartbeat::to_key_type (&dummy))).Times (1);
     this->attach (&dummy);
     this->detach (&dummy);
-    worker_.step ();
+    worker_->step ();
 }
 
 TEST_F (HeartbeatAttachDetach, AttachTwo) {
@@ -111,7 +114,7 @@ TEST_F (HeartbeatAttachDetach, AttachTwo) {
     EXPECT_CALL (callback_, callback (pstore::heartbeat::to_key_type (&second))).Times (2);
     this->attach (&first);
     this->attach (&second);
-    worker_.step ();
+    worker_->step ();
 }
 
 TEST_F (HeartbeatAttachDetach, AttachTwoDetachOne) {
@@ -121,7 +124,7 @@ TEST_F (HeartbeatAttachDetach, AttachTwoDetachOne) {
     EXPECT_CALL (callback_, callback (pstore::heartbeat::to_key_type (&second))).Times (2);
     this->attach (&first);
     this->attach (&second);
-    worker_.step ();
+    worker_->step ();
     this->detach (&second);
-    worker_.step ();
+    worker_->step ();
 }


### PR DESCRIPTION
The heartbeat unittests run as part of the pstore core unittests. They would confusingly rename the thread to 'heartbeat' which was misleading if a later core test failed. 