### PR TITLE
Implement the ability to create a Docker Image for 'pstore'.

### DIFF
--- a/utils/docker/README
+++ b/utils/docker/README
@@ -1,0 +1,35 @@
+Ability to create a Docker image for 'pstore'
+
+Usage: build_docker_image.sh [options] [-- [cmake_args]...]
+
+Available options:
+  General:
+    -h|--help               show this help message
+  Docker-specific:
+    -t|--docker-tag         docker tag for the image
+    -d|--docker-repository  docker repository for the image
+  Checkout arguments:
+    -b|--branch             svn branch to checkout, i.e. 'trunk',
+                            'branches/release_40'
+                            (default: 'trunk')
+  Build-specific:
+    -i|--install-target     name of a cmake install target to build and
+                            include in the resulting archive. Can be
+                            specified multiple times.
+
+Required options: --docker-repository, at least one --install-target.
+
+All options after '--' are passed to CMake invocation.
+
+For example, running:
+  build_docker_image.sh \
+    --branch master --docker-repository pstore --docker-tag latest \
+    --install-target install-clang --install-target install-pstore \
+    -- -DCMAKE_BUILD_TYPE=Release
+
+will produce a docker image:
+    pstore:latest - a small image with preinstalled release versions of
+                    clang and pstore, build from the 'master' branch.
+
+For additional information see llvm/docs/Docker.rst for details
+

--- a/utils/docker/build_docker_image.sh
+++ b/utils/docker/build_docker_image.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+#===- llvm/tools/pstore/utils/docker/build_docker_image.sh ----------------===//
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===-----------------------------------------------------------------------===//
+set -e
+
+IMAGE_SOURCE="pstore"
+DOCKER_REPOSITORY=""
+DOCKER_TAG=""
+BUILDSCRIPT_ARGS=""
+CHECKOUT_ARGS=""
+
+function show_usage() {
+  cat << EOF
+Usage: build_docker_image.sh [options] [-- [cmake_args]...]
+
+Available options:
+  General:
+    -h|--help               show this help message
+  Docker-specific:
+    -t|--docker-tag         docker tag for the image
+    -d|--docker-repository  docker repository for the image
+  Checkout arguments:
+    -b|--branch             svn branch to checkout, i.e. 'trunk',
+                            'branches/release_40'
+                            (default: 'trunk')
+  Build-specific:
+    -i|--install-target     name of a cmake install target to build and
+                            include in the resulting archive. Can be
+                            specified multiple times.
+
+Required options: --docker-repository, at least one --install-target.
+
+All options after '--' are passed to CMake invocation.
+
+For example, running:
+  build_docker_image.sh \
+    --branch master --docker-repository pstore --docker-tag latest \
+    --install-target install-clang --install-target install-pstore \
+    -- -DCMAKE_BUILD_TYPE=Release
+
+will produce a docker image:
+    pstore:latest - a small image with preinstalled release versions of
+                    clang and pstore, build from the 'master' branch.
+EOF
+}
+
+SEEN_INSTALL_TARGET=0
+SEEN_CMAKE_ARGS=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      show_usage
+      exit 0
+      ;;
+    -d|--docker-repository)
+      shift
+      DOCKER_REPOSITORY="$1"
+      shift
+      ;;
+    -t|--docker-tag)
+      shift
+      DOCKER_TAG="$1"
+      shift
+      ;;
+    -b|--branch)
+      CHECKOUT_ARGS="$CHECKOUT_ARGS $1 $2"
+      shift 2
+      ;;
+    -i|--install-target)
+      SEEN_INSTALL_TARGET=1
+      BUILDSCRIPT_ARGS="$BUILDSCRIPT_ARGS $1 $2"
+      shift 2
+      ;;
+    --)
+      shift
+      BUILDSCRIPT_ARGS="$BUILDSCRIPT_ARGS -- $*"
+      SEEN_CMAKE_ARGS=1
+      shift $#
+      ;;
+    *)
+      echo "Unknown argument $1"
+      exit 1
+      ;;
+  esac
+done
+
+command -v docker >/dev/null ||
+  {
+    echo "Docker binary cannot be found. Please install Docker to use this script."
+    exit 1
+  }
+
+if [ "$DOCKER_REPOSITORY" == "" ]; then
+  echo "Required argument missing: --docker-repository"
+  exit 1
+fi
+
+if [ $SEEN_INSTALL_TARGET -eq 0 ]; then
+  echo "Please provide at least one --install-target"
+  exit 1
+fi
+
+SOURCE_DIR=$(dirname $0)
+if [ ! -d "$SOURCE_DIR/$IMAGE_SOURCE" ]; then
+  echo "No sources for '$IMAGE_SOURCE' were found in $SOURCE_DIR"
+  exit 1
+fi
+
+BUILD_DIR=$(mktemp -d)
+trap "rm -rf $BUILD_DIR" EXIT
+echo "Using a temporary directory for the build: $BUILD_DIR"
+
+cp -r "$SOURCE_DIR/$IMAGE_SOURCE" "$BUILD_DIR/$IMAGE_SOURCE"
+cp -r "$SOURCE_DIR/scripts" "$BUILD_DIR/scripts"
+
+if [ "$DOCKER_TAG" != "" ]; then
+  DOCKER_TAG=":$DOCKER_TAG"
+fi
+
+echo "BUILDSCRIPT_ARGS:  '$BUILDSCRIPT_ARGS'"
+echo "BUILD_DIR:         '$BUILD_DIR'"
+echo "CHECKOUT_ARGS:     '$CHECKOUT_ARGS'"
+echo "DOCKER_REPOSITORY: '$DOCKER_REPOSITORY'"
+echo "DOCKER_TAG:        '$DOCKER_TAG'"
+echo "IMAGE_SOURCE:      '$IMAGE_SOURCE'"
+
+echo "Building $DOCKER_REPOSITORY$DOCKER_TAG from $IMAGE_SOURCE"
+docker build --tag "$DOCKER_REPOSITORY$DOCKER_TAG" \
+  --build-arg "checkout_args=$CHECKOUT_ARGS" \
+  --build-arg "buildscript_args=$BUILDSCRIPT_ARGS" \
+  --file "$BUILD_DIR/$IMAGE_SOURCE/Dockerfile" \
+  --rm \
+  "$BUILD_DIR"
+echo "Done"

--- a/utils/docker/pstore/Dockerfile
+++ b/utils/docker/pstore/Dockerfile
@@ -1,0 +1,41 @@
+#===- llvm/tools/pstore/utils/docker/pstore/Dockerfile --------------------===//
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===-----------------------------------------------------------------------===//
+
+# Stage 1. Check out LLVM and PStore source code and run the build.
+FROM launcher.gcr.io/google/ubuntu16_04 as builder
+#LABEL maintainer "LLVM Developers"
+
+# Install build dependencies of llvm.
+# First, Update the apt's source list and include the sources of the packages.
+RUN grep deb /etc/apt/sources.list | \
+    sed 's/^deb/deb-src /g' >> /etc/apt/sources.list
+
+# Install compiler, python, ninja and cmake.
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils \
+    build-essential python cmake git ninja-build && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add scripts to create the image.
+ADD scripts /tmp/scripts
+
+# Checkout the source code.
+ARG checkout_args
+RUN echo "checkout_args: " ${checkout_args}
+RUN /tmp/scripts/checkout_pstore.sh ${checkout_args}
+
+# Run the build. Results of the build will be available at /tmp/pstore-install/.
+ARG buildscript_args
+RUN echo "buildscript_args: " ${buildscript_args}
+RUN /tmp/scripts/build_install_pstore.sh --to /tmp/pstore-install ${buildscript_args}
+
+# Stage 2. Produce a minimal release image with build results.
+FROM launcher.gcr.io/google/ubuntu16_04 as pstore-stage
+#LABEL maintainer "LLVM Developers"
+
+# Copy build results of stage 1 to /usr/local.
+COPY --from=builder /tmp/pstore-install/ /usr/local/

--- a/utils/docker/scripts/build_install_pstore.sh
+++ b/utils/docker/scripts/build_install_pstore.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#===- llvm/tools/pstore/utils/docker/scripts/build_install_pstore.sh ------===//
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===-----------------------------------------------------------------------===//
+
+set -e
+
+function show_usage() {
+  cat << EOF
+Usage: build_install_pstore.sh [options] -- [cmake-args]
+
+Run cmake with the specified arguments. Used inside docker container.
+Passes additional -DCMAKE_INSTALL_PREFIX and puts the build results into
+the directory specified by --to option.
+
+Available options:
+  -h|--help           show this help message
+  -i|--install-target name of a cmake install target to build and include in
+                      the resulting archive. Can be specified multiple times.
+  --to                destination directory where to install the targets.
+Required options: --to, at least one --install-target.
+
+All options after '--' are passed to CMake invocation.
+EOF
+}
+
+CMAKE_ARGS=""
+CMAKE_INSTALL_TARGETS=""
+PSTORE_INSTALL_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -i|--install-target)
+      shift
+      CMAKE_INSTALL_TARGETS="$CMAKE_INSTALL_TARGETS $1"
+      shift
+      ;;
+    --to)
+      shift
+      PSTORE_INSTALL_DIR="$1"
+      shift
+      ;;
+    --)
+      shift
+      CMAKE_ARGS="$*"
+      shift $#
+      ;;
+    -h|--help)
+      show_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+  esac
+done
+
+if [ "$CMAKE_INSTALL_TARGETS" == "" ]; then
+  echo "No install targets. Please pass one or more --install-target."
+  exit 1
+fi
+
+if [ "$PSTORE_INSTALL_DIR" == "" ]; then
+  echo "No install directory. Please specify the --to argument."
+  exit 1
+fi
+
+PSTORE_BUILD_DIR=/tmp/pstore-build
+
+mkdir -p "$PSTORE_INSTALL_DIR"
+
+mkdir -p "$PSTORE_BUILD_DIR/build"
+pushd "$PSTORE_BUILD_DIR/build"
+
+# Run the build as specified in the build arguments.
+echo "Running build"
+echo "cmake -GNinja"
+echo "      -DCMAKE_INSTALL_PREFIX=$PSTORE_INSTALL_DIR"
+echo "      $CMAKE_ARGS"
+echo "      $PSTORE_BUILD_DIR/src/llvm"
+cmake -GNinja \
+  -DCMAKE_INSTALL_PREFIX="$PSTORE_INSTALL_DIR" \
+  $CMAKE_ARGS \
+  "$PSTORE_BUILD_DIR/src/llvm"
+ninja $CMAKE_INSTALL_TARGETS
+
+popd
+
+# Cleanup.
+rm -rf "$PSTORE_BUILD_DIR/build"
+
+echo "Done"

--- a/utils/docker/scripts/checkout_pstore.sh
+++ b/utils/docker/scripts/checkout_pstore.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#===- llvm/tools/pstore/utils/docker/scripts/checkout_pstore.sh -----------===//
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===-----------------------------------------------------------------------===//
+
+set -e
+
+function show_usage() {
+  cat << EOF
+Usage: checkout_pstore.sh [options]
+
+Checkout git sources into /tmp/clang-build/src. Used inside a docker container.
+
+Available options:
+  -h|--help           show this help message
+  -b|--branch         svn branch to checkout, i.e. 'trunk',
+                      'branches/release_40'
+                      (default: 'trunk')
+EOF
+}
+
+REMOTE_BRANCH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -b|--branch)
+      shift
+      REMOTE_BRANCH="$1"
+      shift
+      ;;
+    -h|--help)
+      show_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+  esac
+done
+
+if [ "$REMOTE_BRANCH" == "" ]; then
+  REMOTE_BRANCH="master"
+fi
+
+PSTORE_BUILD_DIR=/tmp/pstore-build
+
+# Get the sources from git.
+echo "Checking out sources from git"
+CHECKOUT_DIR="$PSTORE_BUILD_DIR/src/"
+mkdir -p $CHECKOUT_DIR
+
+REMOTE_REPO="https://github.com/SNSystems"
+LLVM_PROJECT="llvm-prepo.git"
+CLANG_PROJECT="clang-prepo.git"
+PSTORE_PROJECT="pstore.git"
+
+function clone_project() {
+  local PROJ="$1"
+  local DEST="$2"
+  local BRANCH=$REMOTE_BRANCH
+
+  # Check if remote branch exists.
+  set +e
+  git ls-remote --heads --exit-code $REMOTE_REPO/$PROJ $BRANCH
+  if [ "$?" == "2" ]; then
+    echo "Branch $BRANCH does not exist. Using 'master'."
+    BRANCH="master"
+  fi
+  set -e
+  echo "Checking out $BRANCH/$1 to $DEST"
+  git clone --branch $BRANCH $REMOTE_REPO/$PROJ $DEST
+}
+
+cd $CHECKOUT_DIR
+clone_project $LLVM_PROJECT llvm
+
+cd $CHECKOUT_DIR/llvm/tools
+clone_project $CLANG_PROJECT clang
+clone_project $PSTORE_PROJECT pstore
+cd -
+
+echo "Done"


### PR DESCRIPTION
Ability to create a Docker image for 'pstore'.

This work is based on the 'llvm/utils/docker' scripts, but targeting 'pstore'. It requires the 'install-pstore' feature.

Usage: build_docker_image.sh [options] [-- [cmake_args]...]

Available options:
  General:
    -h|--help               show this help message
  Docker-specific:
    -t|--docker-tag         docker tag for the image
    -d|--docker-repository  docker repository for the image
  Checkout arguments:
    -b|--branch             svn branch to checkout, i.e. 'trunk',
                            'branches/release_40'
                            (default: 'trunk')
  Build-specific:
    -i|--install-target     name of a cmake install target to build and
                            include in the resulting archive. Can be
                            specified multiple times.

Required options: --docker-repository, at least one --install-target.

All options after '--' are passed to CMake invocation.

For example, running:
  build_docker_image.sh \
    --branch master --docker-repository pstore --docker-tag latest \
    --install-target install-clang --install-target install-pstore \
    -- -DCMAKE_BUILD_TYPE=Release

will produce a docker image:
    pstore:latest - a small image with preinstalled release versions of
                    clang and pstore, build from the 'master' branch.

The image can be executed with:
docker run -t -i pstore:latest /bin/bash
