### PR TITLE
Use cmake option ‘PSTORE_ENABLE_BROKER’ to disable the broker library and tool build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,8 @@ option (PSTORE_CRC_CHECKS_ENABLED "Perform CRC checks on pstore header and foote
 option (PSTORE_POSIX_SMALL_FILES "On POSIX systems, keep pstore files as small as possible")
 option (PSTORE_ALWAYS_SPANNING "A debugging aid which forces all requests to behave as 'spanning' pointers")
 
-option (PSTORE_ENABLE_BROKER_TESTS "Run broker system tests. Disable if the compiler does not support exceptions." Yes)
+# FIXME: PSTORE_ENABLE_BROKER is only implemented to enable testing with the early prepo compiler that doesn't yet support exceptions.
+option (PSTORE_ENABLE_BROKER "Build broker related libraries and tools and run broker system tests. Disable if the compiler does not support exceptions." Yes)
 option (PSTORE_VALGRIND "Run unit tests using Valgrind (if available).")
 option (PSTORE_COVERAGE "Enable generation of coverage reports.")
 option (PSTORE_DISABLE_UINT128_T "Disable support for __uint128_t")
@@ -213,7 +214,7 @@ if (PSTORE_EXAMPLES)
     list (APPEND LIT_PARAMS --param examples)
 endif ()
 # Add the broker system tests to the collection of tests.
-if (PSTORE_ENABLE_BROKER_TESTS)
+if (PSTORE_ENABLE_BROKER)
     list (APPEND LIT_PARAMS --param broker)
 endif ()
 
@@ -225,17 +226,32 @@ add_custom_target (pstore-system-tests
     VERBATIM
 )
 set_target_properties (pstore-system-tests PROPERTIES FOLDER "pstore tests")
-add_dependencies (pstore-system-tests
-    pstore-broker-poker
-    pstore-brokerd
-    pstore-dump
-    pstore-hamt-test
-    pstore-mangle
-    pstore-read
-    pstore-sieve
-    pstore-vacuumd
-    pstore-write
-)
+
+if (PSTORE_ENABLE_BROKER)
+    add_dependencies (pstore-system-tests
+        pstore-broker-poker
+        pstore-brokerd
+        pstore-dump
+        pstore-hamt-test
+        pstore-mangle
+        pstore-read
+        pstore-sieve
+        pstore-vacuumd
+        pstore-write
+    )
+else ()
+    add_dependencies (pstore-system-tests
+        pstore-broker-poker
+        pstore-dump
+        pstore-hamt-test
+        pstore-mangle
+        pstore-read
+        pstore-sieve
+        pstore-vacuumd
+        pstore-write
+    )
+endif ()
+
 if (PSTORE_EXAMPLES)
    set_target_properties (pstore-examples PROPERTIES FOLDER "pstore examples")
    set_target_properties (pstore-examples-serialize PROPERTIES FOLDER "pstore examples")

--- a/lib/broker/CMakeLists.txt
+++ b/lib/broker/CMakeLists.txt
@@ -42,60 +42,66 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
 #===----------------------------------------------------------------------===//
 
-set (BROKER_PUBLIC_INCLUDES_DIR "${PSTORE_ROOT_DIR}/include/pstore")
-
-set (PSTORE_BROKER_LIB_SRC
-    "${BROKER_PUBLIC_INCLUDES_DIR}/broker/bimap.hpp"
-    "${BROKER_PUBLIC_INCLUDES_DIR}/broker/command.hpp"
-    "${BROKER_PUBLIC_INCLUDES_DIR}/broker/gc.hpp"
-    "${BROKER_PUBLIC_INCLUDES_DIR}/broker/globals.hpp"
-    "${BROKER_PUBLIC_INCLUDES_DIR}/broker/intrusive_list.hpp"
-    "${BROKER_PUBLIC_INCLUDES_DIR}/broker/message_pool.hpp"
-    "${BROKER_PUBLIC_INCLUDES_DIR}/broker/message_queue.hpp"
-    "${BROKER_PUBLIC_INCLUDES_DIR}/broker/parser.hpp"
-    "${BROKER_PUBLIC_INCLUDES_DIR}/broker/pointer_compare.hpp"
-    "${BROKER_PUBLIC_INCLUDES_DIR}/broker/quit.hpp"
-    "${BROKER_PUBLIC_INCLUDES_DIR}/broker/read_loop.hpp"
-    "${BROKER_PUBLIC_INCLUDES_DIR}/broker/recorder.hpp"
-    "${BROKER_PUBLIC_INCLUDES_DIR}/broker/scavenger.hpp"
-    "${BROKER_PUBLIC_INCLUDES_DIR}/broker/spawn.hpp"
-    "${BROKER_PUBLIC_INCLUDES_DIR}/broker/status_server.hpp"
-
-    command.cpp
-    gc_common.cpp
-    gc_posix.cpp
-    gc_win32.cpp
-    globals.cpp
-    message_pool.cpp
-    parser.cpp
-    quit.cpp
-    read_loop_posix.cpp
-    read_loop_win32.cpp
-    recorder.cpp
-    scavenger.cpp
-    spawn_posix.cpp
-    spawn_win32.cpp
-    status_server.cpp
-)
-
-include (add_pstore)
-if (PSTORE_IS_INSIDE_LLVM)
-    set (LLVM_REQUIRES_EH Yes)
-    set (LLVM_REQUIRES_RTTI Yes)
-    add_pstore_library (pstore-broker STATIC ${PSTORE_BROKER_LIB_SRC})
-    target_link_libraries (pstore-broker PUBLIC
-        pstore-broker-intf-ex
-        pstore-json-lib-ex
-        pstore-support-ex
-    )
-    set (LLVM_REQUIRES_EH No)
-    set (LLVM_REQUIRES_RTTI No)
+if (NOT PSTORE_ENABLE_BROKER)
+    message (STATUS "pstore broker library is excluded (PSTORE_ENABLE_BROKER)")
 else ()
-    add_pstore_library (pstore-broker ${PSTORE_BROKER_LIB_SRC})
-    target_link_libraries (pstore-broker PUBLIC
-        pstore-broker-intf
-        pstore-httpd-lib
-        pstore-json-lib
-        pstore-support
+
+    set (BROKER_PUBLIC_INCLUDES_DIR "${PSTORE_ROOT_DIR}/include/pstore")
+
+    set (PSTORE_BROKER_LIB_SRC
+        "${BROKER_PUBLIC_INCLUDES_DIR}/broker/bimap.hpp"
+        "${BROKER_PUBLIC_INCLUDES_DIR}/broker/command.hpp"
+        "${BROKER_PUBLIC_INCLUDES_DIR}/broker/gc.hpp"
+        "${BROKER_PUBLIC_INCLUDES_DIR}/broker/globals.hpp"
+        "${BROKER_PUBLIC_INCLUDES_DIR}/broker/intrusive_list.hpp"
+        "${BROKER_PUBLIC_INCLUDES_DIR}/broker/message_pool.hpp"
+        "${BROKER_PUBLIC_INCLUDES_DIR}/broker/message_queue.hpp"
+        "${BROKER_PUBLIC_INCLUDES_DIR}/broker/parser.hpp"
+        "${BROKER_PUBLIC_INCLUDES_DIR}/broker/pointer_compare.hpp"
+        "${BROKER_PUBLIC_INCLUDES_DIR}/broker/quit.hpp"
+        "${BROKER_PUBLIC_INCLUDES_DIR}/broker/read_loop.hpp"
+        "${BROKER_PUBLIC_INCLUDES_DIR}/broker/recorder.hpp"
+        "${BROKER_PUBLIC_INCLUDES_DIR}/broker/scavenger.hpp"
+        "${BROKER_PUBLIC_INCLUDES_DIR}/broker/spawn.hpp"
+        "${BROKER_PUBLIC_INCLUDES_DIR}/broker/status_server.hpp"
+
+        command.cpp
+        gc_common.cpp
+        gc_posix.cpp
+        gc_win32.cpp
+        globals.cpp
+        message_pool.cpp
+        parser.cpp
+        quit.cpp
+        read_loop_posix.cpp
+        read_loop_win32.cpp
+        recorder.cpp
+        scavenger.cpp
+        spawn_posix.cpp
+        spawn_win32.cpp
+        status_server.cpp
     )
-endif (PSTORE_IS_INSIDE_LLVM)
+
+    include (add_pstore)
+    if (PSTORE_IS_INSIDE_LLVM)
+        set (LLVM_REQUIRES_EH Yes)
+        set (LLVM_REQUIRES_RTTI Yes)
+        add_pstore_library (pstore-broker STATIC ${PSTORE_BROKER_LIB_SRC})
+        target_link_libraries (pstore-broker PUBLIC
+            pstore-broker-intf-ex
+            pstore-json-lib-ex
+            pstore-support-ex
+        )
+        set (LLVM_REQUIRES_EH No)
+        set (LLVM_REQUIRES_RTTI No)
+    else ()
+        add_pstore_library (pstore-broker ${PSTORE_BROKER_LIB_SRC})
+        target_link_libraries (pstore-broker PUBLIC
+            pstore-broker-intf
+            pstore-httpd-lib
+            pstore-json-lib
+            pstore-support
+        )
+    endif (PSTORE_IS_INSIDE_LLVM)
+
+endif (NOT PSTORE_ENABLE_BROKER)

--- a/tools/brokerd/CMakeLists.txt
+++ b/tools/brokerd/CMakeLists.txt
@@ -42,40 +42,46 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
 #===----------------------------------------------------------------------===//
 
-include (add_pstore)
-include (clang_tidy)
-
-###########################
-# pstore-brokerd Executable
-###########################
-
-if (PSTORE_IS_INSIDE_LLVM)
-    set (LLVM_REQUIRES_EH Yes)
-    set (LLVM_REQUIRES_RTTI Yes)
-endif ()
-add_pstore_tool (pstore-brokerd
-    main.cpp
-    switches.hpp
-    switches.cpp
-)
-if (PSTORE_IS_INSIDE_LLVM)
-    set (LLVM_REQUIRES_EH No)
-    set (LLVM_REQUIRES_RTTI No)
-endif ()
-
-if (PSTORE_IS_INSIDE_LLVM)
-target_link_libraries (pstore-brokerd PRIVATE pstore-cmd-util-ex pstore-broker)
+if (NOT PSTORE_ENABLE_BROKER)
+    message (STATUS "pstore broker tool is excluded (PSTORE_ENABLE_BROKER)")
 else ()
-target_link_libraries (pstore-brokerd PRIVATE pstore-cmd-util pstore-broker)
-endif ()
 
-add_clang_tidy_target (pstore-broker)
-run_pstore_unit_test (pstore-brokerd pstore-broker-unit-tests)
+    include (add_pstore)
+    include (clang_tidy)
+
+    ###########################
+    # pstore-brokerd Executable
+    ###########################
+
+    if (PSTORE_IS_INSIDE_LLVM)
+        set (LLVM_REQUIRES_EH Yes)
+        set (LLVM_REQUIRES_RTTI Yes)
+    endif ()
+    add_pstore_tool (pstore-brokerd
+        main.cpp
+        switches.hpp
+        switches.cpp
+    )
+    if (PSTORE_IS_INSIDE_LLVM)
+        set (LLVM_REQUIRES_EH No)
+        set (LLVM_REQUIRES_RTTI No)
+    endif ()
+
+    if (PSTORE_IS_INSIDE_LLVM)
+        target_link_libraries (pstore-brokerd PRIVATE pstore-cmd-util-ex pstore-broker)
+    else ()
+        target_link_libraries (pstore-brokerd PRIVATE pstore-cmd-util pstore-broker)
+    endif ()
+
+    add_clang_tidy_target (pstore-broker)
+    run_pstore_unit_test (pstore-brokerd pstore-broker-unit-tests)
 
 
-#######################
-# pstore_broker_service
-#######################
-if (WIN32)
-    add_subdirectory (service)
+    #######################
+    # pstore_broker_service
+    #######################
+    if (WIN32)
+        add_subdirectory (service)
+    endif ()
+
 endif ()

--- a/unittests/broker/CMakeLists.txt
+++ b/unittests/broker/CMakeLists.txt
@@ -42,16 +42,21 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
 #===----------------------------------------------------------------------===//
 
-include (add_pstore)
-add_pstore_unit_test (pstore-broker-unit-tests
-    test_bimap.cpp
-    test_command.cpp
-    test_intrusive_list.cpp
-    test_parser.cpp
-    test_spawn.cpp
-)
+if (NOT PSTORE_ENABLE_BROKER)
+    message (STATUS "pstore broker unittests is excluded (PSTORE_ENABLE_BROKER)")
+else ()
 
-# Access the library's private include directory.
-target_include_directories (pstore-broker-unit-tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../lib/pstore")
+    include (add_pstore)
+    add_pstore_unit_test (pstore-broker-unit-tests
+        test_bimap.cpp
+        test_command.cpp
+        test_intrusive_list.cpp
+        test_parser.cpp
+        test_spawn.cpp
+    )
 
-target_link_libraries (pstore-broker-unit-tests PRIVATE pstore-broker)
+    # Access the library's private include directory.
+    target_include_directories (pstore-broker-unit-tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../lib/pstore")
+
+    target_link_libraries (pstore-broker-unit-tests PRIVATE pstore-broker)
+endif ()


### PR DESCRIPTION
Fixed for the issue < https://github.com/SNSystems/pstore/issues/33>.

The pstore broker library and tool need the compiler support exceptions. There is a cmake option ‘PSTORE_ENABLE_BROKER_TESTS’, which is used to disable the broker system test if the compiler does not support exceptions. This option is used to disable broker libraries and tools build as well.