### PR TITLE
Add the global value visibility to the compilation_member to support the dynamic library.

### DIFF
--- a/include/pstore/core/file_header.hpp
+++ b/include/pstore/core/file_header.hpp
@@ -117,7 +117,7 @@ namespace pstore {
         std::uint32_t get_crc () const noexcept;
 
         static std::uint16_t const major_version = 1;
-        static std::uint16_t const minor_version = 3;
+        static std::uint16_t const minor_version = 4;
 
         static std::array<std::uint8_t, 4> const file_signature1;
         static std::uint32_t const file_signature2 = 0x0507FFFF;

--- a/include/pstore/mcrepo/compilation.hpp
+++ b/include/pstore/mcrepo/compilation.hpp
@@ -69,6 +69,15 @@ namespace pstore {
 
         std::ostream & operator<< (std::ostream & os, linkage_type l);
 
+#define PSTORE_REPO_VISIBILITY_TYPES                                                               \
+    X (default_visibility)                                                                         \
+    X (hidden_visibility)                                                                          \
+    X (protected_visibility)
+
+#define X(a) a,
+        enum class visibility_type : std::uint8_t { PSTORE_REPO_VISIBILITY_TYPES };
+#undef X
+
         //*                    _ _      _   _                            _              *
         //*  __ ___ _ __  _ __(_) |__ _| |_(_)___ _ _    _ __  ___ _ __ | |__  ___ _ _  *
         //* / _/ _ \ '  \| '_ \ | / _` |  _| / _ \ ' \  | '  \/ -_) '  \| '_ \/ -_) '_| *
@@ -83,12 +92,14 @@ namespace pstore {
             /// \param x  The fragment extent for this compilation symbol.
             /// \param n  Symbol name address.
             /// \param l  The symbol linkage.
+            /// \param v  The symbol visibility.
             compilation_member (index::digest d, extent<fragment> x,
-                                typed_address<indirect_string> n, linkage_type l)
+                                typed_address<indirect_string> n, linkage_type l, visibility_type v)
                     : digest{d}
                     , fext{x}
                     , name{n}
-                    , linkage{l} {}
+                    , linkage{l}
+                    , visibility{v} {}
 
             /// The digest of the fragment reference by this compilation symbol.
             index::digest digest;
@@ -96,10 +107,9 @@ namespace pstore {
             extent<fragment> fext;
             typed_address<indirect_string> name;
             linkage_type linkage;
-            // TODO: eliminate this padding.
-            std::uint8_t padding1 = 0;
-            std::uint16_t padding2 = 0;
-            std::uint32_t padding3 = 0;
+            visibility_type visibility;
+            std::uint16_t padding1 = 0;
+            std::uint32_t padding2 = 0;
 
             /// \brief Returns a pointer to an in-store compilation member instance.
             ///
@@ -123,8 +133,9 @@ namespace pstore {
         PSTORE_STATIC_ASSERT (offsetof (compilation_member, fext) == 16);
         PSTORE_STATIC_ASSERT (offsetof (compilation_member, name) == 32);
         PSTORE_STATIC_ASSERT (offsetof (compilation_member, linkage) == 40);
-        PSTORE_STATIC_ASSERT (offsetof (compilation_member, padding1) == 41);
-        PSTORE_STATIC_ASSERT (offsetof (compilation_member, padding2) == 42);
+        PSTORE_STATIC_ASSERT (offsetof (compilation_member, visibility) == 41);
+        PSTORE_STATIC_ASSERT (offsetof (compilation_member, padding1) == 42);
+        PSTORE_STATIC_ASSERT (offsetof (compilation_member, padding2) == 44);
 
         //*                    _ _      _   _           *
         //*  __ ___ _ __  _ __(_) |__ _| |_(_)___ _ _   *

--- a/lib/dump/mcrepo_value.cpp
+++ b/lib/dump/mcrepo_value.cpp
@@ -179,12 +179,22 @@ namespace pstore {
 
         value_ptr make_value (repo::linkage_type t) {
 #define X(a)                                                                                       \
-    case (repo::linkage_type::a): Name = #a; break;
+    case (repo::linkage_type::a): name = #a; break;
 
-            char const * Name = "*unknown*";
+            char const * name = "*unknown*";
             switch (t) { PSTORE_REPO_LINKAGE_TYPES }
-            return make_value (Name);
+            return make_value (name);
 #undef X
+        }
+
+        value_ptr make_value (repo::visibility_type v) {
+            char const * name = "*unknown*";
+            switch (v) {
+            case repo::visibility_type::default_visibility: name = "default"; break;
+            case repo::visibility_type::hidden_visibility: name = "hidden"; break;
+            case repo::visibility_type::protected_visibility: name = "protected"; break;
+            }
+            return make_value (name);
         }
 
         value_ptr make_value (database const & db, repo::compilation_member const & member) {
@@ -195,6 +205,7 @@ namespace pstore {
                 {"fext", make_value (member.fext)},
                 {"name", make_value (indirect_string::read (db, member.name))},
                 {"linkage", make_value (member.linkage)},
+                {"visibility", make_value (member.visibility)},
             });
         }
 

--- a/unittests/dump/test_mcrepo.cpp
+++ b/unittests/dump/test_mcrepo.cpp
@@ -163,7 +163,7 @@ TEST_F (MCRepoFixture, DumpFragment) {
             compilation_member{pstore::index::digest{28U},
                                pstore::extent<pstore::repo::fragment> (
                                    pstore::typed_address<pstore::repo::fragment>::make (5), 7U),
-                               name, linkage_type::internal};
+                               name, linkage_type::internal, visibility_type::default_visibility};
     }
 
     std::array<pstore::typed_address<compilation_member>, 1> dependents{{addr}};
@@ -184,7 +184,7 @@ TEST_F (MCRepoFixture, DumpFragment) {
     value->write (out);
 
     auto const lines = split_lines (out.str ());
-    ASSERT_EQ (19U, lines.size ());
+    ASSERT_EQ (20U, lines.size ());
 
     auto line = 0U;
     EXPECT_THAT (split_tokens (lines.at (line++)), ElementsAre ());
@@ -211,6 +211,8 @@ TEST_F (MCRepoFixture, DumpFragment) {
                  ElementsAre ("fext", ":", "{", "addr:", "0x5,", "size:", "0x7", "}"));
     EXPECT_THAT (split_tokens (lines.at (line++)), ElementsAre ("name", ":", "foo"));
     EXPECT_THAT (split_tokens (lines.at (line++)), ElementsAre ("linkage", ":", "internal"));
+    EXPECT_THAT (split_tokens (lines.at (line++)),
+                 ElementsAre ("visibility", ":", "default"));
 }
 
 TEST_F (MCRepoFixture, DumpCompilation) {
@@ -223,7 +225,8 @@ TEST_F (MCRepoFixture, DumpCompilation) {
         {pstore::index::digest{28U},
          pstore::extent<pstore::repo::fragment> (
              pstore::typed_address<pstore::repo::fragment>::make (5), 7U),
-         this->store_str (transaction, "main"), linkage_type::external}};
+         this->store_str (transaction, "main"), linkage_type::external,
+         visibility_type::hidden_visibility}};
     auto compilation = compilation::load (
         *db_, compilation::alloc (transaction, this->store_str (transaction, "/home/user/"),
                                   this->store_str (transaction, "machine-vendor-os"),
@@ -234,7 +237,7 @@ TEST_F (MCRepoFixture, DumpCompilation) {
     addr->write (out);
 
     auto const lines = split_lines (out.str ());
-    ASSERT_EQ (7U, lines.size ());
+    ASSERT_EQ (8U, lines.size ());
 
     auto line = 0U;
     EXPECT_THAT (split_tokens (lines.at (line++)), ElementsAre ("members", ":"));
@@ -244,6 +247,7 @@ TEST_F (MCRepoFixture, DumpCompilation) {
                  ElementsAre ("fext", ":", "{", "addr:", "0x5,", "size:", "0x7", "}"));
     EXPECT_THAT (split_tokens (lines.at (line++)), ElementsAre ("name", ":", "main"));
     EXPECT_THAT (split_tokens (lines.at (line++)), ElementsAre ("linkage", ":", "external"));
+    EXPECT_THAT (split_tokens (lines.at (line++)), ElementsAre ("visibility", ":", "hidden"));
     EXPECT_THAT (split_tokens (lines.at (line++)), ElementsAre ("path", ":", "/home/user/"));
     EXPECT_THAT (split_tokens (lines.at (line++)),
                  ElementsAre ("triple", ":", "machine-vendor-os"));

--- a/unittests/mcrepo/test_compilation.cpp
+++ b/unittests/mcrepo/test_compilation.cpp
@@ -84,8 +84,9 @@ TEST_F (CompilationTest, SingleMember) {
         pstore::typed_address<pstore::repo::fragment>::make (3), 5U);
     constexpr auto name = indirect_string_address (32U);
     constexpr auto linkage = pstore::repo::linkage_type::external;
+    constexpr auto visibility = pstore::repo::visibility_type::protected_visibility;
 
-    compilation_member sm{digest, extent, name, linkage};
+    compilation_member sm{digest, extent, name, linkage, visibility};
 
     std::vector<compilation_member> v{sm};
     compilation::alloc (transaction_, output_file_path, triple, std::begin (v), std::end (v));
@@ -101,6 +102,7 @@ TEST_F (CompilationTest, SingleMember) {
     EXPECT_EQ (extent, (*t)[0].fext);
     EXPECT_EQ (name, (*t)[0].name);
     EXPECT_EQ (linkage, (*t)[0].linkage);
+    EXPECT_EQ (visibility, (*t)[0].visibility);
 }
 
 TEST_F (CompilationTest, MultipleMembers) {
@@ -114,9 +116,10 @@ TEST_F (CompilationTest, MultipleMembers) {
         pstore::typed_address<pstore::repo::fragment>::make (2), 2U);
     constexpr auto name = indirect_string_address (16U);
     constexpr auto linkage = pstore::repo::linkage_type::external;
+    constexpr auto visibility = pstore::repo::visibility_type::default_visibility;
 
-    compilation_member mm1{digest1, extent1, name, linkage};
-    compilation_member mm2{digest2, extent2, name + 24U, linkage};
+    compilation_member mm1{digest1, extent1, name, linkage, visibility};
+    compilation_member mm2{digest2, extent2, name + 24U, linkage, visibility};
 
     std::vector<compilation_member> v{mm1, mm2};
     compilation::alloc (transaction_, output_file_path, triple, std::begin (v), std::end (v));
@@ -128,5 +131,6 @@ TEST_F (CompilationTest, MultipleMembers) {
     EXPECT_EQ (128U, t->size_bytes ());
     for (auto const & m : *t) {
         EXPECT_EQ (linkage, m.linkage);
+        EXPECT_EQ (visibility, m.visibility);
     }
 }


### PR DESCRIPTION
This pull request is a part of the fix for <https://github.com/SNSystems/llvm-project-prepo/issues/12>.
