### PR TITLE
Issue #43 ("Add support for VS2019 to make_build")

### DIFF
--- a/utils/make_build.py
+++ b/utils/make_build.py
@@ -96,232 +96,261 @@ def _select_vs_generator():
     }.get(max(installations)), '-A', 'x64', '-T', 'host=x64']
 
 
-def _select_generator(system):
+def _get_real_generator_args(system, generator):
     """
-    Select the most appropriate generator based on system.
-
-    Will either return None if the default generator is to be used, a real cmake generator name, or a "psuedo"
-    generator name. The latter is turned into a collection of cmake switches by _get_real_generator().
+    Turns a target system name and optional generator name into a series of CMake switches.
 
     :param system: The name of the target system.
-    :return: The name of a cmake generator, a "psuedo" generator, or None if the default generator is preferred.
+    :param generator:  The name of the CMake generator (or a "pseudo" generator) or None if the generator is to
+                       be derived from the target system name.
+    :return: An array of cmake switches.
     """
 
-    return {
-        'win32': lambda: 'vs',
-        'mac': lambda: 'Xcode',
-        'linux': lambda: 'Ninja' if _find_on_path(_add_executable_extension('ninja')) is not None else 'make'
-    }.get(system.lower(), lambda: None)()
-
-
-def _get_real_generator(system, generator):
     if generator is None:
-        generator = _select_generator(system)
-    if generator is None:
-        return None
+        #    Select the most appropriate generator based on system.
+        generator = {
+            'linux': lambda: 'Ninja' if _find_on_path(_add_executable_extension('ninja')) is not None else 'make',
+            'mac': lambda: 'Xcode',
+            'win32': lambda: 'vs',
+        }.get(system.lower(), lambda: None)()
+
+    # Turn a generator or "pseudo generator" name into a collection of one or more cmake switches.
     return {
         'make': lambda: ['-G', 'Unix Makefiles'],
-        'vs': _select_vs_generator,
         'ninja': lambda: ['-G', 'Ninja'],
+        'vs': _select_vs_generator,
         'xcode': lambda: ['-G', 'Xcode'],
-    }.get (generator.lower(), lambda: ['-G', generator])()
+    }.get(generator.lower(), lambda: ['-G', generator])()
 
 
-def _options (args):
-    platform_name = sys.platform.lower ()
+def _options(args):
+    platform_name = sys.platform.lower()
     # Prior to python 3.3, Linux included a version number in its name.
-    if platform_name.startswith ('linux'):
+    if platform_name.startswith('linux'):
         platform_name = 'linux'
     elif platform_name == 'darwin':
         platform_name = 'mac'
 
-    parser = argparse.ArgumentParser (description='Generate a build using cmake')
-    parser.add_argument ('build_dir', nargs='?', default=os.getcwd ())
-    parser.add_argument ('-s', '--system', default=platform_name)
-    parser.add_argument ('-c', '--configuration', default='Debug')
-    parser.add_argument ('-o', '--directory', help='The directory in which the build will be created. Normally derived from the system name.')
-    parser.add_argument ('-G', '--generator', help='The build system generator which will be used. Automatically derived from the system name.')
-    parser.add_argument ('-D', '--define', help='Define a cmake variable as <var>:<type>=<value>', action='append')
-    parser.add_argument ('-n', '--dry-run', action='store_true', help='Previews the operation without performing any action.')
-    parser.add_argument ('--no-clean', dest='clean', action='store_false')
-    options = parser.parse_args (args)
+    parser = argparse.ArgumentParser(description='Generate a build using cmake')
+    parser.add_argument('build_dir', nargs='?', default=os.getcwd())
+    parser.add_argument('-s', '--system', default=platform_name, help='The target system name')
+    parser.add_argument('-c', '--configuration', help='The build configuration (Debug/Release)')
+    parser.add_argument('-o', '--directory',
+                        help='The directory in which the build will be created. Normally derived from the system name.')
+    parser.add_argument('-G', '--generator',
+                        help='The build system generator which will be used. Automatically derived from the system name.')
+    parser.add_argument('-D', '--define',
+                        help='Define a cmake variable as <var>:<type>=<value>', action='append', default=[])
+    parser.add_argument('-n', '--dry-run',
+                        action='store_true', help='Previews the operation without performing any action.')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Produce verbose output.')
+    parser.add_argument('--no-clean', dest='clean', action='store_false')
+    options = parser.parse_args(args)
 
     if options.directory is None:
         options.directory = 'build_' + options.system
-    options.generator = _get_real_generator(options.system, options.generator)
+
+    if options.configuration:
+        # The configuration value precedes other defines to allow them to override.
+        configuration = ['CMAKE_BUILD_TYPE:STRING=' + options.configuration]
+        configuration.extend(options.define)
+        options.define = configuration
+
+    options.generator = _get_real_generator_args(options.system, options.generator)
     _logger.debug('Selecting generator %s', str(options.generator))
     return options
 
 
-def _get_log_level (options):
-    return logging.INFO if options.verbose else logging.WARNING
+def _as_command_line(cmd):
+    """
+    Returns an array of arguments into a string which are suitably quoted for the command-shell.
+
+    :param cmd: An array of command-line arguments.
+    :return: A string containing the space-separated arguments with quoting as necessary for the shell.
+    """
+
+    return ' '.join((pipes.quote(x) for x in cmd))
 
 
-def _as_command_line (cmd):
-    return ' '.join (( pipes.quote (x) for x in cmd ))
-
-
-def _as_native_path (path):
-    """Returns the supplied path in its native form. This is only necessary on cygwin where we can't
+def _as_native_path_cygwin(path):
+    """
+    Returns the supplied path in its native form. This is only necessary on cygwin where we can't
     pass a cygwin-style path to the cmake executable.
     """
 
-    if sys.platform == 'cygwin':
-        cmd = [ '/usr/bin/cygpath.exe', '-w', path ]
-        _logger.info ('Converting path to native: %s', _as_command_line (cmd))
-        path = subprocess.check_output (cmd).rstrip ()
-        _logger.info ('Path is: "%s"', path)
-
+    cmd = ['/usr/bin/cygpath.exe', '-w', path]
+    _logger.info('Converting path to native: %s', _as_command_line(cmd))
+    path = subprocess.check_output(cmd).rstrip()
+    _logger.info('Path is: "%s"', path)
     return path
 
 
-def _add_executable_extension (file_name):
-    """Adds the file extension for an executable, if the host system
-    requires one."""
+def _add_executable_extension_windows(file_name):
+    """
+    Adds the Windows .exe file extension for an executable if it isn't there already.
 
-    if sys.platform == 'win32':
-        # If we're running on Windows, then we need to add the ".exe"
-        # suffix to the name of the executable if it isn't there already
-        # (and it shouldn't be, for the sake of portability).
-        root, extension = os.path.splitext (file_name)
-        if extension != '.exe':
-            if extension != '.':
-                extension += '.'
-            extension += 'exe'
-            file_name = root + extension
+    :param file_name: The name of an executable.
+    :return: The name of an executable with the .exe extension.
+    """
+
+    root, extension = os.path.splitext(file_name)
+    if extension != '.exe':
+        if extension != '.':
+            extension += '.'
+        extension += 'exe'
+        file_name = root + extension
 
     return file_name
 
 
-def _split_search_path_windows (search_path):
-    """Splits a Windows-style search path into a list of the component paths.
+def _split_search_path_windows(search_path):
+    """
+    Splits a Windows-style search path into a list of the component paths.
 
-    Arguments:
-        The search path to be split.
-
-    Returns:
-        A list containing each individual path in the search path.
+    :param search_path: The search path to be split.
+    :return: A list containing each individual path in the search path.
     """
 
     quoting = False
-    result = list ()
+    result = list()
     current = ''
     for character in search_path:
-        if   character == '"' and quoting:
+        if character == '"' and quoting:
             quoting = False
         elif character == '"':
             quoting = True
         elif character == ntpath.pathsep and not quoting:
             # Note that DOS path members may contain environment variables which
             # must be expanded.
-            current = ntpath.expandvars (current)
-            result.append (current)
-            current = ""
+            result.append(ntpath.expandvars(current))
+            current = ''
         else:
             current += character
 
-    if len (current) > 0:
-        current = ntpath.expandvars (current)
-        result.append (current)
+    if len(current) > 0:
+        current = ntpath.expandvars(current)
+        result.append(current)
 
     return result
 
 
-def _split_search_path_generic (search_path):
-    """Splits the search path into a list of the component paths."""
+_as_native_path = _as_native_path_cygwin if sys.platform == 'cygwin' else lambda path: path
 
-    return search_path.split (os.pathsep)
+_add_executable_extension = _add_executable_extension_windows if sys.platform == 'win32' else lambda name: name
+
+_split_search_path = _split_search_path_windows if sys.platform == 'win32' else lambda sp: sp.split(os.pathsep)
 
 
-def _find_on_path (file_name):
-    split_search_path = _split_search_path_windows if sys.platform == 'win32' else _split_search_path_generic
-    for p in split_search_path (os.environ ['PATH']):
-        if len (p) > 0:
-            path = os.path.join (p, file_name)
-            if os.path.exists (path):
+def _find_on_path(file_name):
+    """
+    Searches for a file with the supplied name on the search path defined by the PATH environment variable.
+
+    :param file_name:  The file name to be found.
+    :return: The path to a file with the supplied name or None if not found.
+    """
+
+    for p in _split_search_path(os.environ['PATH']):
+        if len(p) > 0:
+            path = os.path.join(p, file_name)
+            if os.path.exists(path):
                 return path
     return None
 
 
-def find_cmake ():
+def find_cmake():
     """
     Searches for the cmake executable, returning its path if found or None otherwise.
     """
 
-    cmake_exe = _add_executable_extension ('cmake')
-    cmake_path = _find_on_path (cmake_exe)
+    cmake_exe = _add_executable_extension('cmake')
+    cmake_path = _find_on_path(cmake_exe)
     if not cmake_path:
-        _logger.error ('Could not find %s on the path', cmake_exe)
+        _logger.error('Could not find %s on the path', cmake_exe)
         return None
     return cmake_path
 
 
-def rmtree_error (function, path, excinfo):
+def create_build_directory(options):
     """
-    Called from shutil.rmtree() if the file removal fails. Makes the file 
-    writable before retrying the operation.
+    Creates the specified build directory, removing an old copy if present and --no-clean was not specified.
+
+    :param options: The user options.
+    :return: Nothing
     """
 
-    os.chmod (path, stat.S_IWRITE)
-    function (path)
-
-
-def create_build_directory (options):
-    if options.clean and os.path.exists (options.directory):
-        _logger.info ('rmtree "%s"', options.directory)
+    if options.clean and os.path.exists(options.directory):
+        _logger.info('rmtree "%s"', options.directory)
         if not options.dry_run:
-            shutil.rmtree (options.directory, onerror=rmtree_error)
+            def rmtree_error(function, path, _):
+                """
+                Called from shutil.rmtree() if the file removal fails. Makes the file
+                writable before retrying the operation.
+                """
 
-    if not os.path.exists (options.directory):
-        _logger.info ('mkdir:%s', options.directory)
+                os.chmod(path, stat.S_IWRITE)
+                function(path)
+
+            shutil.rmtree(options.directory, onerror=rmtree_error)
+
+    if not os.path.exists(options.directory):
+        _logger.info('mkdir:%s', options.directory)
         if not options.dry_run:
-            os.mkdir (options.directory)
+            os.mkdir(options.directory)
 
 
-def build_cmake_command_line (cmake_path, options):
-    cmd = [ cmake_path ]
-    if options.generator is not None:
-        cmd.extend(options.generator)
+def build_cmake_command_line(cmake_path, options):
+    cmd = [cmake_path]
+    cmd.extend(options.generator if options.generator else [])
 
     # Add the user variable definitions.
-    for d in options.define if options.define else []:
-        cmd.extend (( '-D', d ))
+    cmd.extend('-D' + d for d in options.define)
 
     # Finally add the build root directory.
-    cmd.append (_as_native_path (os.path.abspath (options.build_dir)))
+    cmd.append(_as_native_path(os.path.abspath(options.build_dir)))
     return cmd
 
 
-def main (args = sys.argv [1:]):
-    exit_code = EXIT_SUCCESS
-    logging.basicConfig (level=logging.DEBUG)
-    options = _options (args)
-
-    # Check for a cmakelists.txt
-    cmakelists_path = os.path.abspath (os.path.join (options.build_dir, 'CMakeLists.txt'))
+def check_for_cmakelists(options):
+    cmakelists_path = os.path.abspath(os.path.join(options.build_dir, 'CMakeLists.txt'))
     _logger.info('Looking for CMakeLists.txt in "%s"', cmakelists_path)
-    if not os.path.exists (cmakelists_path):
-        _logger.error ('Did not find a CMake CMakeLists.txt file')
-        exit_code = EXIT_FAILURE
+    if not os.path.exists(cmakelists_path):
+        _logger.error('Did not find a CMake CMakeLists.txt file')
+        return ''
+    return cmakelists_path
 
-    cmake_path = None
-    if exit_code == EXIT_SUCCESS:
-        cmake_path = find_cmake ()
-        exit_code = EXIT_FAILURE if cmake_path is None else EXIT_SUCCESS
 
-    if exit_code == EXIT_SUCCESS:
-        create_build_directory (options)
-        cmd = build_cmake_command_line (cmake_path, options)
+def run_cmake(options, cmake_path):
+    create_build_directory(options)
+    cmd = build_cmake_command_line(cmake_path, options)
+    _logger.info('cd "%s"', options.directory)
+    _logger.info('Running: %s', _as_command_line(cmd))
+    if options.dry_run:
+        return True
+    return subprocess.call(cmd, cwd=options.directory) == 0
 
-        _logger.info ('cwd "%s"', options.directory)
-        _logger.info ('Running: %s', _as_command_line (cmd))
-        if not options.dry_run:
-            status = subprocess.call (cmd, cwd=options.directory)
-            if status:
-                exit_code = EXIT_FAILURE
 
-    return exit_code
+def bind(x, f):
+    """
+    A monadic bind operation similar to Haskell's Maybe type. Used to enable function
+    composition where a function returning a false-like value indicates failure.
+
+    :param x: The input value passed to callable f is not None.
+    :param f: A callable which is passed 'x'
+    :return: If 'x' is a false value on input, 'x' otherwise the result of calling f(x).
+    """
+
+    return f(x) if x else x
+
+
+def main(args=sys.argv[1:]):
+    options = _options(args)
+    logging.basicConfig(level=logging.DEBUG if options.verbose else logging.INFO)
+    _logger.debug('Defines are: %s', str(options.define))
+
+    return bind(check_for_cmakelists(options),
+                lambda _: bind(find_cmake(),
+                               lambda cmake_path: run_cmake(options, cmake_path)))
 
 
 if __name__ == '__main__':
-    sys.exit (main ())
+    sys.exit(EXIT_SUCCESS if main() else EXIT_FAILURE)

--- a/utils/make_build.py
+++ b/utils/make_build.py
@@ -92,7 +92,7 @@ def _select_vs_generator():
     # Ask vswhere to disclose all of the vs installations.
     installations = json.loads(subprocess.check_output([vswhere, '-format', 'json'], stderr=subprocess.STDOUT))
     # Reduce the installations list to just the integer major version numbers.
-    installations = (int(install['installationVersion'].split('.')[0]) for install in installations)
+    installations = [int(install['installationVersion'].split('.')[0]) for install in installations]
     _logger.debug('Installations are: %s', ','.join((str(inst) for inst in installations)))
     return {
         16: 'Visual Studio 16 2019',
@@ -295,7 +295,7 @@ def build_cmake_command_line (cmake_path, options):
     for d in options.define if options.define else []:
         cmd.extend (( '-D', d ))
 
-    if options.generator is not None and options.startswith('Visual Studio'):
+    if options.generator is not None and options.generator.startswith('Visual Studio'):
         cmd.extend (('-T', 'host=x64'))
 
     # Finally add the build root directory.


### PR DESCRIPTION
We must discover which versions of Visual Studio are installed then
pick the correct generator string for the latest version that we
find. If an error occurs, we default back to the cmake default generator.