### PR TITLE
linkage_type -> linkage.

### DIFF
--- a/include/pstore/dump/mcrepo_value.hpp
+++ b/include/pstore/dump/mcrepo_value.hpp
@@ -68,7 +68,7 @@ namespace pstore {
         value_ptr make_fragment_value (database const & db, repo::fragment const & fragment,
                                        gsl::czstring triple, bool hex_mode);
 
-        value_ptr make_value (repo::linkage_type t);
+        value_ptr make_value (repo::linkage l);
         value_ptr make_value (repo::visibility_type t);
         value_ptr make_value (database const & db, repo::compilation_member const & member);
         value_ptr make_value (database const & db,

--- a/include/pstore/mcrepo/compilation.hpp
+++ b/include/pstore/mcrepo/compilation.hpp
@@ -52,7 +52,7 @@
 namespace pstore {
     namespace repo {
 
-#define PSTORE_REPO_LINKAGE_TYPES                                                                  \
+#define PSTORE_REPO_LINKAGES                                                                       \
     X (append)                                                                                     \
     X (common)                                                                                     \
     X (external)                                                                                   \
@@ -64,10 +64,10 @@ namespace pstore {
     X (weak_odr)
 
 #define X(a) a,
-        enum class linkage_type : std::uint8_t { PSTORE_REPO_LINKAGE_TYPES };
+        enum class linkage : std::uint8_t { PSTORE_REPO_LINKAGES };
 #undef X
 
-        std::ostream & operator<< (std::ostream & os, linkage_type l);
+        std::ostream & operator<< (std::ostream & os, linkage l);
 
 #define PSTORE_REPO_VISIBILITY_TYPES                                                               \
     X (default_visibility)                                                                         \
@@ -94,7 +94,7 @@ namespace pstore {
             /// \param l  The symbol linkage.
             /// \param v  The symbol visibility.
             compilation_member (index::digest d, extent<fragment> x,
-                                typed_address<indirect_string> n, linkage_type l,
+                                typed_address<indirect_string> n, linkage l,
                                 visibility_type v = visibility_type::default_visibility)
                     : digest{d}
                     , fext{x}
@@ -107,7 +107,7 @@ namespace pstore {
             /// The extent of the fragment referenced by this compilation symbol.
             extent<fragment> fext;
             typed_address<indirect_string> name;
-            linkage_type linkage;
+            repo::linkage linkage;
             visibility_type visibility;
             std::uint16_t padding1 = 0;
             std::uint32_t padding2 = 0;

--- a/lib/dump/mcrepo_value.cpp
+++ b/lib/dump/mcrepo_value.cpp
@@ -177,12 +177,12 @@ namespace pstore {
 #undef X
         }
 
-        value_ptr make_value (repo::linkage_type t) {
+        value_ptr make_value (repo::linkage l) {
 #define X(a)                                                                                       \
-    case (repo::linkage_type::a): name = #a; break;
+    case (repo::linkage::a): name = #a; break;
 
             char const * name = "*unknown*";
-            switch (t) { PSTORE_REPO_LINKAGE_TYPES }
+            switch (l) { PSTORE_REPO_LINKAGES }
             return make_value (name);
 #undef X
         }

--- a/lib/mcrepo/compilation.cpp
+++ b/lib/mcrepo/compilation.cpp
@@ -47,12 +47,12 @@
 
 using namespace pstore::repo;
 
-std::ostream & pstore::repo::operator<< (std::ostream & os, linkage_type l) {
+std::ostream & pstore::repo::operator<< (std::ostream & os, linkage l) {
     char const * str = "unknown";
     switch (l) {
 #define X(a)                                                                                       \
-    case linkage_type::a: str = #a; break;
-        PSTORE_REPO_LINKAGE_TYPES
+    case linkage::a: str = #a; break;
+        PSTORE_REPO_LINKAGES
 #undef X
     }
     return os << str;

--- a/unittests/dump/test_mcrepo.cpp
+++ b/unittests/dump/test_mcrepo.cpp
@@ -163,7 +163,7 @@ TEST_F (MCRepoFixture, DumpFragment) {
             compilation_member{pstore::index::digest{28U},
                                pstore::extent<pstore::repo::fragment> (
                                    pstore::typed_address<pstore::repo::fragment>::make (5), 7U),
-                               name, linkage_type::internal, visibility_type::default_visibility};
+                               name, linkage::internal, visibility_type::default_visibility};
     }
 
     std::array<pstore::typed_address<compilation_member>, 1> dependents{{addr}};
@@ -225,7 +225,7 @@ TEST_F (MCRepoFixture, DumpCompilation) {
         {pstore::index::digest{28U},
          pstore::extent<pstore::repo::fragment> (
              pstore::typed_address<pstore::repo::fragment>::make (5), 7U),
-         this->store_str (transaction, "main"), linkage_type::external,
+         this->store_str (transaction, "main"), linkage::external,
          visibility_type::hidden_visibility}};
     auto compilation = compilation::load (
         *db_, compilation::alloc (transaction, this->store_str (transaction, "/home/user/"),

--- a/unittests/mcrepo/test_compilation.cpp
+++ b/unittests/mcrepo/test_compilation.cpp
@@ -83,7 +83,7 @@ TEST_F (CompilationTest, SingleMember) {
     constexpr auto extent = pstore::extent<pstore::repo::fragment> (
         pstore::typed_address<pstore::repo::fragment>::make (3), 5U);
     constexpr auto name = indirect_string_address (32U);
-    constexpr auto linkage = pstore::repo::linkage_type::external;
+    constexpr auto linkage = pstore::repo::linkage::external;
     constexpr auto visibility = pstore::repo::visibility_type::protected_visibility;
 
     compilation_member sm{digest, extent, name, linkage, visibility};
@@ -115,7 +115,7 @@ TEST_F (CompilationTest, MultipleMembers) {
     constexpr auto extent2 = pstore::extent<pstore::repo::fragment> (
         pstore::typed_address<pstore::repo::fragment>::make (2), 2U);
     constexpr auto name = indirect_string_address (16U);
-    constexpr auto linkage = pstore::repo::linkage_type::external;
+    constexpr auto linkage = pstore::repo::linkage::external;
     constexpr auto visibility = pstore::repo::visibility_type::default_visibility;
 
     compilation_member mm1{digest1, extent1, name, linkage, visibility};


### PR DESCRIPTION
I’ve grown to dislike types that include a suffix of “type” for no very good reason. This PR changes the `linkage_type` enumeration to `linkage`. There will obviously need to be corresponding changes in the dependent repos.