### PR TITLE
Add PstoreUnitTests to new check-pstore target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,10 @@ endif ()
 if (PSTORE_IS_INSIDE_LLVM)
     add_custom_target (PstoreUnitTests)
     set_target_properties(PstoreUnitTests PROPERTIES FOLDER "pstore tests")
+    add_lit_testsuite(check-pstore "Running the Pstore regression tests"
+        ${CMAKE_CURRENT_BINARY_DIR}
+         DEPENDS PstoreUnitTests
+        )
 endif (PSTORE_IS_INSIDE_LLVM)
 
 


### PR DESCRIPTION
This also integrates the pstore unit tests into the check-all target.

This aids in setting up CI for llvm-project-prepo.