### PR TITLE
Enable check-pstore to run pstore unittests as well as build them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,9 @@ if (NOT PSTORE_IS_INSIDE_LLVM)
 endif ()
 set (PSTORE_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
+# Define pstore source and binary dirs similar to the definitions in clang
+set(PSTORE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(PSTORE_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
 if (MSVC)
     # Microsoft's linker/archiver (not sure which) likes to warn when it sees
@@ -162,10 +165,6 @@ endif ()
 if (PSTORE_IS_INSIDE_LLVM)
     add_custom_target (PstoreUnitTests)
     set_target_properties(PstoreUnitTests PROPERTIES FOLDER "pstore tests")
-    add_lit_testsuite(check-pstore "Running the Pstore regression tests"
-        ${CMAKE_CURRENT_BINARY_DIR}
-         DEPENDS PstoreUnitTests
-        )
 endif (PSTORE_IS_INSIDE_LLVM)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,8 @@ endif ()
 set (PSTORE_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
 # Define pstore source and binary dirs similar to the definitions in clang
-set(PSTORE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(PSTORE_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+set (PSTORE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set (PSTORE_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
 if (MSVC)
     # Microsoft's linker/archiver (not sure which) likes to warn when it sees

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -55,25 +55,25 @@ target_include_directories (pstore-unit-test-harness PRIVATE ../include)
 if (PSTORE_IS_INSIDE_LLVM)
     include_directories (${LLVM_MAIN_SRC_DIR}/utils/unittest/googletest/include)
     include_directories (${LLVM_MAIN_SRC_DIR}/utils/unittest/googlemock/include)
-    configure_lit_site_cfg(
-      ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
-      ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
-      MAIN_CONFIG
-      ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
-      )
+    configure_lit_site_cfg (
+        ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+        ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+        MAIN_CONFIG
+        ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+        )
 
-    list(APPEND PSTORE_TEST_DEPS PstoreUnitTests)
+    list (APPEND PSTORE_TEST_DEPS PstoreUnitTests)
 
-    add_custom_target(pstore-test-depends DEPENDS ${PSTORE_TEST_DEPS})
-    set_target_properties(pstore-test-depends PROPERTIES FOLDER "pstore tests")
+    add_custom_target (pstore-test-depends DEPENDS ${PSTORE_TEST_DEPS})
+    set_target_properties (pstore-test-depends PROPERTIES FOLDER "pstore tests")
 
-    add_lit_testsuite(check-pstore "Running the Pstore regression tests"
-      ${CMAKE_CURRENT_BINARY_DIR}
-      PARAMS ${PSTORE_TEST_PARAMS}
-      DEPENDS ${PSTORE_TEST_DEPS}
-      ARGS ${PSTORE_TEST_EXTRA_ARGS}
-      )
-    set_target_properties(check-pstore PROPERTIES FOLDER "pstore tests")
+    add_lit_testsuite (check-pstore "Running the pstore regression tests"
+        ${CMAKE_CURRENT_BINARY_DIR}
+        PARAMS ${PSTORE_TEST_PARAMS}
+        DEPENDS ${PSTORE_TEST_DEPS}
+        ARGS ${PSTORE_TEST_EXTRA_ARGS}
+        )
+    set_target_properties (check-pstore PROPERTIES FOLDER "pstore tests")
 endif (PSTORE_IS_INSIDE_LLVM)
 
 add_subdirectory (klee EXCLUDE_FROM_ALL)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -55,6 +55,25 @@ target_include_directories (pstore-unit-test-harness PRIVATE ../include)
 if (PSTORE_IS_INSIDE_LLVM)
     include_directories (${LLVM_MAIN_SRC_DIR}/utils/unittest/googletest/include)
     include_directories (${LLVM_MAIN_SRC_DIR}/utils/unittest/googlemock/include)
+    configure_lit_site_cfg(
+      ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+      ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+      MAIN_CONFIG
+      ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+      )
+
+    list(APPEND PSTORE_TEST_DEPS PstoreUnitTests)
+
+    add_custom_target(pstore-test-depends DEPENDS ${PSTORE_TEST_DEPS})
+    set_target_properties(pstore-test-depends PROPERTIES FOLDER "pstore tests")
+
+    add_lit_testsuite(check-pstore "Running the Pstore regression tests"
+      ${CMAKE_CURRENT_BINARY_DIR}
+      PARAMS ${PSTORE_TEST_PARAMS}
+      DEPENDS ${PSTORE_TEST_DEPS}
+      ARGS ${PSTORE_TEST_EXTRA_ARGS}
+      )
+    set_target_properties(check-pstore PROPERTIES FOLDER "pstore tests")
 endif (PSTORE_IS_INSIDE_LLVM)
 
 add_subdirectory (klee EXCLUDE_FROM_ALL)

--- a/unittests/lit.cfg.py
+++ b/unittests/lit.cfg.py
@@ -6,7 +6,7 @@ import os
 import lit.formats
 
 # name: The name of this test suite.
-config.name = 'Pstore-Unit'
+config.name = 'pstore-Unit'
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = []

--- a/unittests/lit.cfg.py
+++ b/unittests/lit.cfg.py
@@ -1,4 +1,47 @@
 # -*- Python -*-
+# *  _ _ _          __        *
+# * | (_) |_   ___ / _| __ _  *
+# * | | | __| / __| |_ / _` | *
+# * | | | |_ | (__|  _| (_| | *
+# * |_|_|\__(_)___|_|  \__, | *
+# *                    |___/  *
+# ===- unittests/lit.cfg.py -----------------------------------------------===//
+#  Copyright (c) 2017-2020 by Sony Interactive Entertainment, Inc.
+#  All rights reserved.
+#
+#  Developed by:
+#    Toolchain Team
+#    SN Systems, Ltd.
+#    www.snsystems.com
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the
+#  "Software"), to deal with the Software without restriction, including
+#  without limitation the rights to use, copy, modify, merge, publish,
+#  distribute, sublicense, and/or sell copies of the Software, and to
+#  permit persons to whom the Software is furnished to do so, subject to
+#  the following conditions:
+#
+#  - Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimers.
+#
+#  - Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimers in the
+#    documentation and/or other materials provided with the distribution.
+#
+#  - Neither the names of SN Systems Ltd., Sony Interactive Entertainment,
+#    Inc. nor the names of its contributors may be used to endorse or
+#    promote products derived from this Software without specific prior
+#    written permission.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+#  IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+#  ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+#  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+#  SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
+# ===----------------------------------------------------------------------===//
 
 # Configuration file for the 'lit' test runner.
 

--- a/unittests/lit.cfg.py
+++ b/unittests/lit.cfg.py
@@ -1,0 +1,27 @@
+# -*- Python -*-
+
+# Configuration file for the 'lit' test runner.
+
+import os
+import lit.formats
+
+# name: The name of this test suite.
+config.name = 'Pstore-Unit'
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = []
+
+# test_source_root: The root path where tests are located.
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.pstore_obj_root, 'unittests')
+config.test_source_root = config.test_exec_root
+
+# testFormat: The test format to use to interpret tests.
+config.test_format = lit.formats.GoogleTest(config.llvm_build_mode, 'unit-tests')
+
+# Propagate the temp directory. Windows requires this because it uses \Windows\
+# if none of these are present.
+if 'TMP' in os.environ:
+    config.environment['TMP'] = os.environ['TMP']
+if 'TEMP' in os.environ:
+    config.environment['TEMP'] = os.environ['TEMP']

--- a/unittests/lit.site.cfg.py.in
+++ b/unittests/lit.site.cfg.py.in
@@ -1,0 +1,20 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+
+config.llvm_src_root = "@LLVM_SOURCE_DIR@"
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_build_mode = "@LLVM_BUILD_MODE@"
+config.pstore_obj_root = "@PSTORE_BINARY_DIR@"
+
+# Support substitution of the build_mode with user parameters. This is used
+# when we can't determine the tool dir at configuration time.
+try:
+    config.llvm_build_mode = config.llvm_build_mode % lit_config.params
+except KeyError:
+    e = sys.exc_info()[1]
+    key, = e.args
+    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@PSTORE_SOURCE_DIR@/unittests/lit.cfg.py")


### PR DESCRIPTION
#50 attempted to run pstore unit tests under check-all but only hooked up building them. This actually hooks them up to run through lit (as with LLVM) so this integrates into check-all and can produce xunit.xml data.