### PR TITLE
Use chunked_vector to store in-heap internal-nodes.

### DIFF
--- a/include/pstore/core/hamt_map.hpp
+++ b/include/pstore/core/hamt_map.hpp
@@ -49,6 +49,7 @@
 #include <iterator>
 #include <type_traits>
 
+#include "pstore/adt/chunked_vector.hpp"
 #include "pstore/core/database.hpp"
 #include "pstore/core/db_archive.hpp"
 #include "pstore/core/hamt_map_fwd.hpp"
@@ -457,6 +458,27 @@ namespace pstore {
             /// internal or linear node.
             void delete_node (index_pointer node, unsigned shifts);
 
+            static constexpr auto internal_nodes_per_chunk =
+                std::size_t{256} * 1024 / sizeof (internal_node);
+
+            /// Internal nodes are allocated using a "chunked-vector". This allocates memory in
+            /// lumps sufficent for internal_nodes_per_chunk entries. This is then consumed as new
+            /// in-heap internal nodes are created.
+            ///
+            /// The effect of this is to significantly reduce the number of memory allocations
+            /// performed by the index code under heavy insertion pressure as thus give us a little
+            /// extra performance. The cost is that we may waste as much as one chunk's worth of
+            /// memory (minus sizeof (internal_node).
+            ///
+            /// TODO: we allocate nodes at their maximum size even though they may only contain two
+            /// members. This is rather wasteful and will prevent us from moving to larger hash
+            /// sizes due to the bloated memory consumption.
+            using internal_nodes_container =
+                chunked_vector<internal_node, internal_nodes_per_chunk,
+                               sizeof (internal_node) +
+                                   sizeof (index_pointer) * sizeof (hash_type) * 8U - 1U>;
+            std::unique_ptr<internal_nodes_container> internals_container_;
+
             unsigned revision_;
             index_pointer root_;
             std::size_t size_ = 0;
@@ -588,7 +610,8 @@ namespace pstore {
         hamt_map<KeyType, ValueType, Hash, KeyEqual>::hamt_map (
             database const & db, typed_address<header_block> const pos, Hash const & hash,
             KeyEqual const & equal)
-                : revision_{db.get_current_revision ()}
+                : internals_container_{std::make_unique<internal_nodes_container> ()}
+                , revision_{db.get_current_revision ()}
                 , hash_{hash}
                 , equal_{equal} {
 
@@ -697,9 +720,8 @@ namespace pstore {
                     address const leaf_addr =
                         this->store_leaf_node (transaction, new_leaf, parents);
                     auto const internal_ptr = index_pointer{
-                        internal_node::allocate (existing_leaf, index_pointer{leaf_addr}, old_hash,
-                                                 new_hash)
-                            .release ()};
+                        internal_node::allocate (internals_container_.get (), existing_leaf,
+                                                 index_pointer{leaf_addr}, old_hash, new_hash)};
                     parents->push (
                         {internal_ptr, internal_node::get_new_index (new_hash, old_hash)});
                     return internal_ptr;
@@ -719,8 +741,8 @@ namespace pstore {
 
                 index_pointer const leaf_ptr = this->insert_into_leaf (
                     transaction, existing_leaf, new_leaf, existing_hash, hash, shifts, parents);
-                auto const internal_ptr =
-                    index_pointer{internal_node::allocate (leaf_ptr, old_hash).release ()};
+                auto const internal_ptr = index_pointer{
+                    internal_node::allocate (internals_container_.get (), leaf_ptr, old_hash)};
                 parents->push ({internal_ptr, 0U});
                 return internal_ptr;
             }
@@ -742,7 +764,9 @@ namespace pstore {
             if (node.is_heap ()) {
                 assert (!node.is_leaf ());
                 if (details::depth_is_internal_node (shifts)) {
-                    delete node.untag_node<internal_node *> ();
+                    // Internal nodes are owned by internals_container_. Don't delete them here. If
+                    // this ever changes, then add something like: delete
+                    // node.untag_node<internal_node *> ();
                 } else {
                     delete node.untag_node<linear_node *> ();
                 }
@@ -771,14 +795,11 @@ namespace pstore {
             // If this slot isn't used, then ensure the node is on the heap, write the new leaf node
             // and point to it.
             if (index == details::not_found) {
-                std::unique_ptr<internal_node> new_node;
-                internal_node * inode = nullptr;
-                std::tie (new_node, inode) = internal_node::make_writable (node, *internal);
-
+                internal_node * const inode =
+                    internal_node::make_writable (internals_container_.get (), node, *internal);
                 inode->insert_child (
                     hash, index_pointer{this->store_leaf_node (transaction, value, parents)},
                     parents);
-                new_node.release ();
                 return {index_pointer{inode}, false};
             }
 
@@ -797,8 +818,8 @@ namespace pstore {
 
             std::unique_ptr<internal_node> new_node;
             if (new_child != child_slot) {
-                internal_node * inode = nullptr;
-                std::tie (new_node, inode) = internal_node::make_writable (node, *internal);
+                internal_node * const inode =
+                    internal_node::make_writable (internals_container_.get (), node, *internal);
 
                 // Release a previous heap-allocated instance.
                 index_pointer & child = (*inode)[index];
@@ -999,7 +1020,8 @@ namespace pstore {
                 assert (root_.is_internal ());
                 auto internal = root_.untag_node<internal_node *> ();
                 root_ = internal->flush (transaction, 0 /* shifts */);
-                delete internal;
+                // Don't delete the internal node here. They are owned by internals_container_. If
+                // this ever changes, then use something like 'delete internal' here.
             }
 
             // Write the index header. This simply holds a check signature, the tree root, and
@@ -1009,8 +1031,12 @@ namespace pstore {
             pos.first->size = this->size ();
             pos.first->root = root_.addr;
 
+            // Release all of the in-heap internal nodes that we have now flushed.
+            internals_container_->clear ();
+
             // Update the revision number into which the index will be flushed.
             revision_ = generation;
+
             return pos.second;
         }
 

--- a/unittests/adt/test_chunked_vector.cpp
+++ b/unittests/adt/test_chunked_vector.cpp
@@ -43,29 +43,84 @@
 //===----------------------------------------------------------------------===//
 #include "pstore/adt/chunked_vector.hpp"
 
+// standard library
 #include <utility>
 
+// pstore includes
+#include "pstore/config/config.hpp"
+
+// 3rd party
 #include <gmock/gmock.h>
 
+namespace {
+
+    // A class which simply wraps and int and doesn't have a default ctor.
+    class simple {
+    public:
+        explicit simple (int v)
+                : v_{v} {}
+        int get () const { return v_; }
+
+    private:
+        int v_;
+    };
+
+    // Limit the chunks to two elements each.
+    using cvector_int = pstore::chunked_vector<int, std::size_t{2}>;
+    using cvector_simple = pstore::chunked_vector<simple, std::size_t{2}>;
+
+} // end anonymous namespace
+
 TEST (ChunkedVector, Init) {
-    pstore::chunked_vector<int> cv;
+    cvector_int cv;
     EXPECT_EQ (cv.size (), 0U);
     EXPECT_EQ (std::distance (std::begin (cv), std::end (cv)), 0);
 }
 
 TEST (ChunkedVector, OneMember) {
-    pstore::chunked_vector<int> cv;
+    cvector_simple cv;
     cv.emplace_back (1);
 
     EXPECT_EQ (cv.size (), 1U);
     auto it = cv.begin ();
-    EXPECT_EQ (*it, 1);
+    EXPECT_EQ (it->get (), 1);
     ++it;
     EXPECT_EQ (it, cv.end ());
 }
 
+TEST (ChunckedVector, PushBack) {
+    cvector_simple cv;
+    simple const & a = cv.push_back (simple{17});
+    simple const & b = cv.push_back (simple{19});
+    simple const & c = cv.push_back (simple{23});
+    EXPECT_EQ (cv.size (), 3U);
+    EXPECT_EQ (a.get (), 17);
+    EXPECT_EQ (b.get (), 19);
+    EXPECT_EQ (c.get (), 23);
+}
+
+TEST (ChunckedVector, EmplaceBack) {
+    cvector_simple cv;
+    simple const & a = cv.emplace_back (17);
+    simple const & b = cv.emplace_back (19);
+    simple const & c = cv.emplace_back (23);
+    EXPECT_EQ (cv.size (), 3U);
+    EXPECT_EQ (a.get (), 17);
+    EXPECT_EQ (b.get (), 19);
+    EXPECT_EQ (c.get (), 23);
+}
+
+TEST (ChunckedVector, FrontAndBack) {
+    cvector_int cv;
+    cv.push_back (17);
+    cv.push_back (19);
+    cv.push_back (23);
+    EXPECT_EQ (cv.front (), 17);
+    EXPECT_EQ (cv.back (), 23);
+}
+
 TEST (ChunkedVector, Swap) {
-    pstore::chunked_vector<int> a, b;
+    cvector_int a, b;
     a.emplace_back (7);
     std::swap (a, b);
     EXPECT_EQ (a.size (), 0U);
@@ -74,10 +129,10 @@ TEST (ChunkedVector, Swap) {
 }
 
 TEST (ChunkedVector, Splice) {
-    pstore::chunked_vector<int> a;
+    cvector_int a;
     a.emplace_back (7);
 
-    pstore::chunked_vector<int> b;
+    cvector_int b;
     b.emplace_back (11);
 
     a.splice (std::move (b));
@@ -85,23 +140,20 @@ TEST (ChunkedVector, Splice) {
 }
 
 TEST (ChunkedVector, IteratorAssign) {
-    pstore::chunked_vector<int> cv;
+    cvector_int cv;
     cv.emplace_back (7);
-    pstore::chunked_vector<int>::iterator it = cv.begin ();
-    pstore::chunked_vector<int>::iterator it2 = it;         // non-const copy ctor from non-const
+    cvector_int::iterator it = cv.begin ();
+    cvector_int::iterator it2 = it;                         // non-const copy ctor from non-const
     it2 = it;                                               // non-const assign from non-const.
-    pstore::chunked_vector<int>::const_iterator cit = it;   // const copy ctor from non-const.
-    pstore::chunked_vector<int>::const_iterator cit2 = cit; // copy ctor from const.
+    cvector_int::const_iterator cit = it;                   // const copy ctor from non-const.
+    cvector_int::const_iterator cit2 = cit;                 // copy ctor from const.
     cit2 = cit;                                             // assign from const.
     cit2 = it;                                              // assign from non-const.
-    pstore::chunked_vector<int>::const_iterator cit3 = std::move (cit); // move ctor from const.
+    cvector_int::const_iterator cit3 = std::move (cit);     // move ctor from const.
     EXPECT_EQ (*cit3, 7);
 }
 
 namespace {
-
-    // Limit the chunks to two elements each.
-    using vector_type = pstore::chunked_vector<int, std::size_t{2}>;
 
     template <typename IteratorType>
     class CVIterator : public testing::Test {
@@ -115,13 +167,17 @@ namespace {
         }
 
     protected:
-        vector_type cv_;
+        cvector_int cv_;
     };
 
 } // end anonymous namespace
 
-using IteratorTypes = testing::Types<vector_type::iterator, vector_type::const_iterator>;
-TYPED_TEST_SUITE (CVIterator, IteratorTypes, );
+using iterator_types = testing::Types<cvector_int::iterator, cvector_int::const_iterator>;
+#ifdef PSTORE_IS_INSIDE_LLVM
+TYPED_TEST_CASE (CVIterator, iterator_types);
+#else
+TYPED_TEST_SUITE (CVIterator, iterator_types, );
+#endif
 
 TYPED_TEST (CVIterator, Preincrement) {
     EXPECT_EQ (this->cv_.size (), 4U);

--- a/unittests/core/test_hamt_map.cpp
+++ b/unittests/core/test_hamt_map.cpp
@@ -100,18 +100,11 @@ TEST_F (IndexFixture, InitAddress) {
 }
 
 // Test initial pointer index pointer.
-TEST_F (IndexFixture, InitPointer) {
-    std::unique_ptr<internal_node> internal = pstore::index::details::internal_node::allocate ();
-    index_pointer index{internal.get ()};
-    EXPECT_TRUE (index.is_heap ());
-    EXPECT_TRUE (index.is_internal ());
-}
-
-// Test initial pointer index pointer.
 TEST_F (IndexFixture, InternalSizeBytes) {
-    EXPECT_EQ (24U, pstore::index::details::internal_node::size_bytes (1));
-    EXPECT_EQ (32U, pstore::index::details::internal_node::size_bytes (2));
-    EXPECT_EQ (528U, pstore::index::details::internal_node::size_bytes (64));
+    using internal_node = pstore::index::details::internal_node;
+    EXPECT_EQ (24U, internal_node::size_bytes (1));
+    EXPECT_EQ (32U, internal_node::size_bytes (2));
+    EXPECT_EQ (528U, internal_node::size_bytes (64));
 }
 
 namespace {


### PR DESCRIPTION
Internal nodes are allocated using a chunked-vector. This allocates
memory in lumps sufficent for internal_nodes_per_chunk entries. This
is then consumed as new in-heap internal nodes are created.

The effect of this is to significantly reduce the number of memory
allocations performed by the index code under heavy insertion pressure
as thus give us a little extra performance. The cost is that we may
waste as much as one chunk's worth of memory [minus
sizeof (internal_node)].