### PR TITLE
Add a digest field to the debug-line section.

### DIFF
--- a/include/pstore/core/address.hpp
+++ b/include/pstore/core/address.hpp
@@ -489,7 +489,7 @@ namespace pstore {
     };
 
     template <typename T>
-    static inline extent<T> make_extent (typed_address<T> a, std::uint64_t s) noexcept {
+    static constexpr extent<T> make_extent (typed_address<T> a, std::uint64_t s) noexcept {
         return {a, s};
     }
 

--- a/include/pstore/core/file_header.hpp
+++ b/include/pstore/core/file_header.hpp
@@ -117,7 +117,7 @@ namespace pstore {
         std::uint32_t get_crc () const noexcept;
 
         static constexpr std::uint16_t major_version = 1;
-        static constexpr std::uint16_t minor_version = 7;
+        static constexpr std::uint16_t minor_version = 8;
 
         static std::array<std::uint8_t, 4> const file_signature1;
         static std::uint32_t const file_signature2 = 0x0507FFFF;

--- a/include/pstore/mcrepo/debug_line_section.hpp
+++ b/include/pstore/mcrepo/debug_line_section.hpp
@@ -51,6 +51,7 @@
 #define PSTORE_MCREPO_DEBUG_LINE_SECTION_HPP
 
 #include "pstore/core/address.hpp"
+#include "pstore/core/index_types.hpp"
 #include "pstore/mcrepo/generic_section.hpp"
 
 namespace pstore {
@@ -62,13 +63,15 @@ namespace pstore {
         public:
             template <typename DataRange, typename IFixupRange, typename XFixupRange>
             debug_line_section (
-                extent<std::uint8_t> const & header_extent,
+                index::digest const & header_digest, extent<std::uint8_t> const & header_extent,
                 generic_section::sources<DataRange, IFixupRange, XFixupRange> const & src,
                 std::uint8_t align)
-                    : header_{header_extent}
+                    : header_digest_{header_digest}
+                    , header_{header_extent}
                     , g_ (src.data_range, src.ifixups_range, src.xfixups_range, align) {}
 
 
+            index::digest const & header_digest () const noexcept { return header_digest_; }
             extent<std::uint8_t> const & header_extent () const noexcept { return header_; }
             generic_section const & generic () const noexcept { return g_; }
 
@@ -98,6 +101,7 @@ namespace pstore {
             }
 
         private:
+            index::digest header_digest_;
             extent<std::uint8_t> header_;
             generic_section g_;
         };
@@ -119,9 +123,11 @@ namespace pstore {
 
         class debug_line_section_creation_dispatcher final : public section_creation_dispatcher {
         public:
-            debug_line_section_creation_dispatcher (extent<std::uint8_t> const & header,
+            debug_line_section_creation_dispatcher (index::digest const & header_digest,
+                                                    extent<std::uint8_t> const & header,
                                                     section_content const * const sec)
                     : section_creation_dispatcher (section_kind::debug_line)
+                    , header_digest_{header_digest}
                     , header_{header}
                     , section_ (sec) {}
 
@@ -137,6 +143,7 @@ namespace pstore {
 
         private:
             std::uintptr_t aligned_impl (std::uintptr_t in) const override;
+            index::digest header_digest_;
             extent<std::uint8_t> header_;
             section_content const * const section_;
         };

--- a/include/pstore/mcrepo/fragment.hpp
+++ b/include/pstore/mcrepo/fragment.hpp
@@ -298,10 +298,12 @@ namespace pstore {
 
                 // Verify that the structure layout is the same regardless of the compiler and
                 // target platform.
-                PSTORE_STATIC_ASSERT (alignof (fragment) == 8);
-                PSTORE_STATIC_ASSERT (sizeof (fragment) == 24);
+                PSTORE_STATIC_ASSERT (alignof (fragment) == 16);
+                PSTORE_STATIC_ASSERT (sizeof (fragment) == 32);
                 PSTORE_STATIC_ASSERT (offsetof (fragment, signature_) == 0);
-                PSTORE_STATIC_ASSERT (offsetof (fragment, arr_) == 8);
+                PSTORE_STATIC_ASSERT (offsetof (fragment, padding1_) == 8);
+                PSTORE_STATIC_ASSERT (offsetof (fragment, arr_) == 16);
+                padding1_ = 0; // assignment to silence an "unused" warning from clang.
 
                 static_assert (
                     std::numeric_limits<member_array::bitmap_type>::radix == 2,
@@ -402,10 +404,11 @@ namespace pstore {
                 {'F', 'r', 'a', 'g', 'm', 'e', 'n', 't'}};
 
             std::array<char, 8> signature_ = fragment_signature_;
+            std::uint64_t padding1_ = 0;
 
             /// A sparse array of offsets to each of the contained sections. (Must be the struct's
             /// last member.)
-            member_array arr_;
+            alignas (16) member_array arr_;
         };
 
         // operator<<
@@ -530,7 +533,7 @@ case section_kind::k: name = #k; break;
 #endif
         }
 
-        // size_bytes
+        // size bytes [static]
         // ~~~~~~~~~~
         template <typename Iterator>
         std::size_t fragment::size_bytes (Iterator first, Iterator last) {

--- a/include/pstore/mcrepo/fragment.hpp
+++ b/include/pstore/mcrepo/fragment.hpp
@@ -407,7 +407,8 @@ namespace pstore {
             std::uint64_t padding1_ = 0;
 
             /// A sparse array of offsets to each of the contained sections. (Must be the struct's
-            /// last member.)
+            /// last member.) It must be aligned at least as much as any of the possible member
+            /// types.
             alignas (16) member_array arr_;
         };
 

--- a/lib/dump/mcrepo_value.cpp
+++ b/lib/dump/mcrepo_value.cpp
@@ -141,6 +141,7 @@ namespace pstore {
                                       bool const hex_mode) {
             assert (sk == repo::section_kind::debug_line);
             return make_value (object::container{
+                {"digest", make_value (section.header_digest ())},
                 {"header", make_value (section.header_extent ())},
                 {"generic", make_section_value (db, section.generic (), sk, triple, hex_mode)},
             });

--- a/unittests/mcrepo/CMakeLists.txt
+++ b/unittests/mcrepo/CMakeLists.txt
@@ -44,9 +44,10 @@
 add_pstore_unit_test (pstore-mcrepo-unit-tests
     test_bss_section.cpp
     test_compilation.cpp
+    test_debug_line_section.cpp
     test_fragment.cpp
     test_sparse_array.cpp
     transaction.cpp
     transaction.hpp
 )
-target_link_libraries (pstore-mcrepo-unit-tests PRIVATE pstore-mcrepo)
+target_link_libraries (pstore-mcrepo-unit-tests PRIVATE pstore-mcrepo pstore-common)


### PR DESCRIPTION
Fix for #62. A debug-line section needs to contain the digest of the debug-line-header (DLH) that it uses in addition to the existing extent field. The latter is fine for a consumer such as repo2obj which just needs to join the two fields together, but an export tool needs to know the digest of DLH value so that this reference can be emitted along with everything else.