### PR TITLE
Including a header to fix a build error when using the vs2109.

### DIFF
--- a/tools/genromfs/copy.cpp
+++ b/tools/genromfs/copy.cpp
@@ -49,6 +49,7 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <tuple>
 
 // pstore includes
 #include "pstore/support/array_elements.hpp"


### PR DESCRIPTION
When I build `llvm-project-prepo` using visual studio 2019 on Windows, I got the following build error: error C2039: 'tie': is not a member of 'std'.

Fixed the build error by including the header.
