### PR TITLE
Fix for assertion when using the LLVM disassembler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,9 @@ endif ()
 if (PSTORE_ENABLE_BROKER)
     list (APPEND LIT_PARAMS --param broker)
 endif ()
+if (PSTORE_IS_INSIDE_LLVM)
+    list (APPEND LIT_PARAMS --param is_inside_llvm)
+endif ()
 
 # Add a target to the build which will run the system tests.
 add_custom_target (pstore-system-tests
@@ -259,11 +262,19 @@ add_custom_target (pstore-system-tests
         ${LIT_PARAMS}
         --echo-all-commands
         "$<TARGET_FILE_DIR:pstore-write>"
-    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    WORKING_DIRECTORY "$<TARGET_FILE_DIR:pstore-write>"
     COMMENT "Running system tests with LIT"
     VERBATIM
 )
 set_target_properties (pstore-system-tests PROPERTIES FOLDER "pstore tests")
+
+if (PSTORE_IS_INSIDE_LLVM)
+    add_dependencies (pstore-system-tests
+        FileCheck
+        llc
+        opt
+    )
+endif ()
 
 add_dependencies (pstore-system-tests
     pstore-broker-poker

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ add_custom_target (pstore-system-tests
         ${LIT_PARAMS}
         --echo-all-commands
         "$<TARGET_FILE_DIR:pstore-write>"
-    WORKING_DIRECTORY "$<TARGET_FILE_DIR:pstore-write>"
+    WORKING_DIRECTORY $<TARGET_FILE_DIR:pstore-write>
     COMMENT "Running system tests with LIT"
     VERBATIM
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ add_custom_target (pstore-system-tests
         ${LIT_PARAMS}
         --echo-all-commands
         "$<TARGET_FILE_DIR:pstore-write>"
-    WORKING_DIRECTORY $<TARGET_FILE_DIR:pstore-write>
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     COMMENT "Running system tests with LIT"
     VERBATIM
 )

--- a/include/pstore/dump/mcdisassembler_value.hpp
+++ b/include/pstore/dump/mcdisassembler_value.hpp
@@ -58,10 +58,9 @@ namespace pstore {
     namespace dump {
 
         value_ptr make_disassembled_value (std::uint8_t const * first, std::uint8_t const * last,
-
                                            gsl::czstring triple, bool hex_mode);
 
-    } // namespace dump
-} // namespace pstore
+    } // end namespace dump
+} // end namespace pstore
 
 #endif // PSTORE_DUMP_MCDISASSEMBLER_VALUE_HPP

--- a/lib/dump/mcdisassembler_value.cpp
+++ b/lib/dump/mcdisassembler_value.cpp
@@ -244,8 +244,9 @@ namespace {
     auto create_asm_info (llvm::Target const & target, llvm::MCRegisterInfo const & register_info,
                           llvm::Triple const & triple) {
         using return_type = error_or<asm_info_ptr>;
-        if (asm_info_ptr asm_info{target.createMCAsmInfo (register_info, triple.getTriple (),
-                                                          llvm::mc::InitMCTargetOptionsFromFlags ())}) {
+        llvm::MCTargetOptions options;
+        if (asm_info_ptr asm_info{
+                target.createMCAsmInfo (register_info, triple.getTriple (), options)}) {
             return return_type{std::move (asm_info)};
         }
         return return_type{make_error_code (error_code::no_assembly_info_for_target)};

--- a/lit.cfg.in
+++ b/lit.cfg.in
@@ -47,6 +47,7 @@ config.name = 'pstore'
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [
     '.cpp',
+    '.ll',
     '.t',
     '.test',
 ]
@@ -88,6 +89,12 @@ if lit_config.params.get ('examples') is not None:
 # add 'broker' if '--param broker' was specified on the command line.
 if lit_config.params.get ('broker') is not None:
     config.available_features.add ('broker')
+
+# Add 'is_inside_llvm' if '--param is_inside_llvm' was on the command line. This
+# should happen to indicate that this build is happening inside the LLVM framework
+# and hence LLVM tools are available.
+if lit_config.params.get ('is_inside_llvm') is not None:
+    config.available_features.add ('is_inside_llvm')
 
 config.substitutions.append (('%binaries', '@LIT_CONFIG_DIR@'))
 config.substitutions.append (('%foo', 'this-is-foo'))

--- a/system_tests/dump/text_section.ll
+++ b/system_tests/dump/text_section.ll
@@ -1,0 +1,24 @@
+; Test for dumping of a fragment's text section. When pstore is built inside LLVM,
+; we use the latter's disassembler library to produce nice disassembled output
+; rather than ASCII-encoded binary. To pass we need simply to dump a section of
+; type text.
+
+; %S = the test source directory
+; %T = the test output directory
+; %binaries = the directories containing the executable binaries
+; %s = source path (path to the file currently being run)
+; %t = temporary file name unique to the test
+
+; REQUIRES: is_inside_llvm
+; RUN: rm -f "%t.db"
+; RUN: env REPOFILE="%t.db" "%binaries/opt" -O0 -S %s -o %t
+; RUN: env REPOFILE="%t.db" "%binaries/llc" -filetype=obj %t
+; RUN: "%binaries/pstore-dump" --all-fragments "%t.db" | "%binaries/FileCheck" %s
+
+; CHECK: type : text
+
+target triple = "x86_64-pc-linux-gnu-repo"
+
+define i32 @f(){
+  ret i32 1
+}


### PR DESCRIPTION
Commit SNSystems/llvm-project-prepo@0c369da5ccc95e7108594217269531b2ac73819d upgraded the llvm-project-prepo to the LLVM 11.x branch point. Unfortunately this introduced a regression in pstore-dump where the call to `InitMCTargetOptionsFromFlags()` triggered an assertion.

It seems likely that this call was always wrong: the “flags” that it’s talking about appear to be drawn from the LLVM command-line options, which obviously isn’t going to work with the pstore command-line parser.

We now pass a default-initialized `MCTargetOptions` to `createMCAsmInfo()`.

Add a system test to avoid this happening again. This means adding the capability of running LLVM tools from inside the pstore test suite.

Fix for issue #66.