### PR TITLE
The LIT %T substitution is now deprecated. Eliminate its use.

### DIFF
--- a/system_tests/bad/empty.test
+++ b/system_tests/bad/empty.test
@@ -1,6 +1,5 @@
 # %binaries = the directories containing the executable binaries
 # %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
 
 XFAIL:*

--- a/system_tests/broker/broker1.test
+++ b/system_tests/broker/broker1.test
@@ -2,13 +2,13 @@
 ## messages at it. We check that the broker responds correctly to those
 ## commands.
 
-# %binaries = the directories containing the executable binaries
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
 
 REQUIRES: broker
-RUN: %python "%S/broker1.py" "%binaries" > "%T/broker1_actual.txt"
-RUN: diff "%T/broker1_actual.txt" "%S/broker1_expected.txt"
+RUN: %python "%S/broker1.py" "%binaries" > "%t"
+RUN: diff "%t" "%S/broker1_expected.txt"
 
 #eof broker1.test
 

--- a/system_tests/broker/httpd.test
+++ b/system_tests/broker/httpd.test
@@ -1,10 +1,10 @@
 ## A test which runs pstore broker and gets the root page from its HTTP server. We check for expected contents in the response.
 
-# %binaries = the directories containing the executable binaries
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
 
 REQUIRES: broker
-RUN: %python "%S/httpd.py" "%binaries" > "%T/http_actual.txt"
+RUN: %python "%S/httpd.py" "%binaries" > "%t"
 
 #eof http.test

--- a/system_tests/dump/text_section.ll
+++ b/system_tests/dump/text_section.ll
@@ -4,7 +4,6 @@
 ; type text.
 
 ; %S = the test source directory
-; %T = the test output directory
 ; %binaries = the directories containing the executable binaries
 ; %s = source path (path to the file currently being run)
 ; %t = temporary file name unique to the test

--- a/system_tests/fuzzing/dump_contents.test.disabled
+++ b/system_tests/fuzzing/dump_contents.test.disabled
@@ -1,10 +1,12 @@
 # This test fuzzes input to the dump utility's --contents switch.
 
-# %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
 
-RUN: "%python" "%S/fuzz.py" --temp-dir="%stores" --binary-dir="%binaries" -- dump_contents "%binaries/pstore-dump" --contents
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
+
+RUN: "%python" "%S/fuzz.py" --temp-dir="%t" --binary-dir="%binaries" -- dump_contents "%binaries/pstore-dump" --contents
 
 #eof dump_contents.test

--- a/system_tests/fuzzing/dump_header.test.disabled
+++ b/system_tests/fuzzing/dump_header.test.disabled
@@ -1,10 +1,12 @@
 # This test fuzzes input to the dump utility's --header switch.
 
-# %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
 
-RUN: "%python" "%S/fuzz.py" --temp-dir="%stores" --binary-dir="%binaries" -- dump_header "%binaries/pstore-dump" --header
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
+
+RUN: "%python" "%S/fuzz.py" --temp-dir="%t" --binary-dir="%binaries" -- dump_header "%binaries/pstore-dump" --header
 
 #eof dump_header.test

--- a/system_tests/fuzzing/dump_indices.test.disabled
+++ b/system_tests/fuzzing/dump_indices.test.disabled
@@ -1,10 +1,12 @@
 # This test fuzzes input to the dump utility's --indices switch.
 
 # %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %t = temporary file name unique to the test
 
-RUN: "%python" "%S/fuzz.py" --temp-dir="%stores" --binary-dir="%binaries" -- dump_indices "%binaries/pstore-dump" --indices
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
+
+RUN: "%python" "%S/fuzz.py" --temp-dir="%t" --binary-dir="%binaries" -- dump_indices "%binaries/pstore-dump" --indices
 
 #eof dump_indices.test

--- a/system_tests/fuzzing/dump_log.test.disabled
+++ b/system_tests/fuzzing/dump_log.test.disabled
@@ -1,10 +1,12 @@
 # This test fuzzes input to the dump utility's --log switch.
 
 # %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %t = temporary file name unique to the test
 
-RUN: "%python" "%S/fuzz.py" --temp-dir="%stores" --binary-dir="%binaries" -- dump_log "%binaries/pstore-dump" --log
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
+
+RUN: "%python" "%S/fuzz.py" --temp-dir="%t" --binary-dir="%binaries" -- dump_log "%binaries/pstore-dump" --log
 
 #eof dump_log.test

--- a/system_tests/fuzzing/dump_shared_memory.test.disabled
+++ b/system_tests/fuzzing/dump_shared_memory.test.disabled
@@ -1,10 +1,12 @@
 # This test fuzzes input to the dump utility's --shared-memory switch.
 
 # %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %t = temporary file name unique to the test
 
-RUN: "%python" "%S/fuzz.py" --temp-dir="%stores" --binary-dir="%binaries" -- dump_shared_memory "%binaries/pstore-dump" --shared-memory
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
+
+RUN: "%python" "%S/fuzz.py" --temp-dir="%t" --binary-dir="%binaries" -- dump_shared_memory "%binaries/pstore-dump" --shared-memory
 
 #eof dump_shared_memory.test

--- a/system_tests/fuzzing/vacuumd.test.disabled
+++ b/system_tests/fuzzing/vacuumd.test.disabled
@@ -1,10 +1,12 @@
 # This test fuzzes input to the vacuumd utility.
 
-# %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
 
-RUN: "%python" "%S/fuzz.py" --temp-dir="%stores" --binary-dir="%binaries" -- vacuumd "%binaries/pstore-vacuumd"
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
+
+RUN: "%python" "%S/fuzz.py" --temp-dir="%t" --binary-dir="%binaries" -- vacuumd "%binaries/pstore-vacuumd"
 
 #eof vacuumd.test

--- a/system_tests/fuzzing/write.test.disabled
+++ b/system_tests/fuzzing/write.test.disabled
@@ -1,13 +1,12 @@
 # This test fuzzes input to the write utility.
 
 # %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %t = temporary file name unique to the test
 
 # Note that the first non-argument switch is the name of the test; subsequent
 # arguments form the command line to be run.
 
-RUN: "%python" "%S/fuzz.py" --temp-dir="%stores" --binary-dir="%binaries" -- write "%binaries/pstore-write" --compact=disabled --add=key3,value3
+RUN: "%python" "%S/fuzz.py" --temp-dir="%t" --binary-dir="%binaries" -- write "%binaries/pstore-write" --compact=disabled --add=key3,value3
 
 #eof write.test

--- a/system_tests/index/dump_missing_file.test
+++ b/system_tests/index/dump_missing_file.test
@@ -1,5 +1,8 @@
 # Try to dump a missing data store.
 XFAIL: *
-RUN: mkdir -p "%T/dump_missing_file"
-RUN: "%binaries/pstore-dump" --log "%T/dump_missing_file/foo.db"
+
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
+
+RUN: "%binaries/pstore-dump" --log "%t/foo.db"
 

--- a/system_tests/index/hamt_test.test.disabled
+++ b/system_tests/index/hamt_test.test.disabled
@@ -1,10 +1,8 @@
-# %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
 
-# Delete an existing data store.
-RUN: rm -f "%stores/hamt_test.db"
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
 
-# Try to run the hamt_test.exe.
-RUN: "%binaries/pstore-hamt-test" "%stores/hamt_test.db"
+RUN: "%binaries/pstore-hamt-test" "%t"

--- a/system_tests/index/large1.test.disabled
+++ b/system_tests/index/large1.test.disabled
@@ -3,41 +3,34 @@
 # original files. All three files are added in a single transaction.
 
 
-# %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
 
 
-# Delete an existing data store (we don't want to end up appending to it)
-RUN: rm -f "%stores/large1.db"
-
-
-# Create a directory to hold the test outputs.
-RUN: rm -r -f "%T/large1"
-RUN: mkdir -p "%T/large1"
-
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
 
 
 # Generate test data: three files full of 32-bit big-endian primes.
-RUN: "%binaries/pstore-sieve" --endian=big --maximum=10000000 -o "%T/large1/p1e7.bin"
-RUN: "%binaries/pstore-sieve" --endian=big --maximum=20000000 -o "%T/large1/p2e7.bin"
-RUN: "%binaries/pstore-sieve" --endian=big --maximum=30000000 -o "%T/large1/p3e7.bin"
+RUN: "%binaries/pstore-sieve" --endian=big --maximum=10000000 -o "%t/p1e7.bin"
+RUN: "%binaries/pstore-sieve" --endian=big --maximum=20000000 -o "%t/p2e7.bin"
+RUN: "%binaries/pstore-sieve" --endian=big --maximum=30000000 -o "%t/p3e7.bin"
 
 # Copy the three files into the data store with the keys 'p1e7', 'p2e7', and
 # 'p3e7' respectively.
-RUN: "%binaries/pstore-write" "--add-file=p1e7,%T/large1/p1e7.bin" \
-RUN:                          "--add-file=p2e7,%T/large1/p2e7.bin" \
-RUN:                          "--add-file=p3e7,%T/large1/p3e7.bin" \
-RUN:                          "%stores/large1.db"
+RUN: "%binaries/pstore-write" "--add-file=p1e7,%t/p1e7.bin" \
+RUN:                          "--add-file=p2e7,%t/p2e7.bin" \
+RUN:                          "--add-file=p3e7,%t/p3e7.bin" \
+RUN:                          "%t/large1.db"
 
 # Read the threes keys and extract the resulting data in correspondingly named files
 # in the test output directory
-RUN: "%binaries/pstore-read" "%stores/large1.db" p1e7 > "%T/large1/p1e7"
-RUN: "%binaries/pstore-read" "%stores/large1.db" p2e7 > "%T/large1/p2e7"
-RUN: "%binaries/pstore-read" "%stores/large1.db" p3e7 > "%T/large1/p3e7"
+RUN: "%binaries/pstore-read" "%t/large1.db" p1e7 > "%t/p1e7"
+RUN: "%binaries/pstore-read" "%t/large1.db" p2e7 > "%t/p2e7"
+RUN: "%binaries/pstore-read" "%t/large1.db" p3e7 > "%t/p3e7"
 
 # Check that the data made the round trip successfully.
-RUN: diff "%T/large1/p1e7" "%T/large1/p1e7.bin"
-RUN: diff "%T/large1/p2e7" "%T/large1/p2e7.bin"
-RUN: diff "%T/large1/p3e7" "%T/large1/p3e7.bin"
+RUN: diff "%t/p1e7" "%t/p1e7.bin"
+RUN: diff "%t/p2e7" "%t/p2e7.bin"
+RUN: diff "%t/p3e7" "%t/p3e7.bin"

--- a/system_tests/index/large2.test.disabled
+++ b/system_tests/index/large2.test.disabled
@@ -3,40 +3,33 @@
 # original files. All three files are added in a single transaction.
 
 
-# %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
 
 
-# Delete an existing data store (we don't want to end up appending to it)
-RUN: rm -f "%stores/large2.db"
-
-
-# Create a directory to hold the test outputs.
-RUN: rm -r -f "%T/large2"
-RUN: mkdir -p "%T/large2"
-
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
 
 
 # Generate test data: three files full of 32-bit big-endian primes.
-RUN: "%binaries/pstore-sieve" --endian=big --maximum=10000000 -o "%T/large2/p1e7.bin"
-RUN: "%binaries/pstore-sieve" --endian=big --maximum=20000000 -o "%T/large2/p2e7.bin"
-RUN: "%binaries/pstore-sieve" --endian=big --maximum=30000000 -o "%T/large2/p3e7.bin"
+RUN: "%binaries/pstore-sieve" --endian=big --maximum=10000000 -o "%t/p1e7.bin"
+RUN: "%binaries/pstore-sieve" --endian=big --maximum=20000000 -o "%t/p2e7.bin"
+RUN: "%binaries/pstore-sieve" --endian=big --maximum=30000000 -o "%t/p3e7.bin"
 
 # Copy the three files into the data store with the keys 'p1e7', 'p2e7', and
 # 'p3e7' respectively. Each is recorded in a separate transaction.
-RUN: "%binaries/pstore-write" "--add-file=p1e7,%T/large2/p1e7.bin" "%stores/large2.db"
-RUN: "%binaries/pstore-write" "--add-file=p2e7,%T/large2/p2e7.bin" "%stores/large2.db"
-RUN: "%binaries/pstore-write" "--add-file=p3e7,%T/large2/p3e7.bin" "%stores/large2.db"
+RUN: "%binaries/pstore-write" "--add-file=p1e7,%t/p1e7.bin" "%t/large2.db"
+RUN: "%binaries/pstore-write" "--add-file=p2e7,%t/p2e7.bin" "%t/large2.db"
+RUN: "%binaries/pstore-write" "--add-file=p3e7,%t/p3e7.bin" "%t/large2.db"
 
 # Read the three keys and extract the resulting data in correspondingly named files
 # in the test output directory
-RUN: "%binaries/pstore-read" "%stores/large2.db" p1e7 > "%T/large2/p1e7"
-RUN: "%binaries/pstore-read" "%stores/large2.db" p2e7 > "%T/large2/p2e7"
-RUN: "%binaries/pstore-read" "%stores/large2.db" p3e7 > "%T/large2/p3e7"
+RUN: "%binaries/pstore-read" "%t/large2.db" p1e7 > "%t/p1e7"
+RUN: "%binaries/pstore-read" "%t/large2.db" p2e7 > "%t/p2e7"
+RUN: "%binaries/pstore-read" "%t/large2.db" p3e7 > "%t/p3e7"
 
 # Check that the data made the round trip successfully.
-RUN: diff "%T/large2/p1e7" "%T/large2/p1e7.bin"
-RUN: diff "%T/large2/p2e7" "%T/large2/p2e7.bin"
-RUN: diff "%T/large2/p3e7" "%T/large2/p3e7.bin"
+RUN: diff "%t/p1e7" "%t/p1e7.bin"
+RUN: diff "%t/p2e7" "%t/p2e7.bin"
+RUN: diff "%t/p3e7" "%t/p3e7.bin"

--- a/system_tests/index/name.test
+++ b/system_tests/index/name.test
@@ -1,30 +1,28 @@
-# %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
 
-# Delete an existing data store.
-RUN: rm -f %stores/name.db
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
 
 # Write three values into the data store
-RUN: "%binaries/pstore-write" "--add-string=key1" "%stores/name.db"
-RUN: "%binaries/pstore-write" "--add-string=key2" "%stores/name.db"
-RUN: "%binaries/pstore-write" "--add-string=key3" "%stores/name.db"
-RUN: "%binaries/pstore-write" "--add-string=key1" "%stores/name.db"
+RUN: "%binaries/pstore-write" "--add-string=key1" "%t/name.db"
+RUN: "%binaries/pstore-write" "--add-string=key2" "%t/name.db"
+RUN: "%binaries/pstore-write" "--add-string=key3" "%t/name.db"
+RUN: "%binaries/pstore-write" "--add-string=key1" "%t/name.db"
 
-RUN: echo "%stores"
 # Read the keys and store the resulting data in a file named read
 # in the test output directory
-RUN: "%binaries/pstore-read" --strings "%stores/name.db" key1 > "%T/name"
-RUN: echo '.' >>  "%T/name"
-RUN: "%binaries/pstore-read" --strings "%stores/name.db" key2 >> "%T/name"
-RUN: echo '.' >>  "%T/name"
-RUN: "%binaries/pstore-read" --strings "%stores/name.db" key3 >> "%T/name"
-RUN: echo '.' >>  "%T/name"
-RUN: "%binaries/pstore-read" --strings "%stores/name.db" key4 >> "%T/name"
-RUN: echo '.' >>  "%T/name"
-RUN: "%binaries/pstore-read" --strings "%stores/name.db" key5 >> "%T/name"
-RUN: echo '.' >>  "%T/name"
+RUN: "%binaries/pstore-read" --strings "%t/name.db" key1 > "%t/name"
+RUN: echo '.' >>  "%t/name"
+RUN: "%binaries/pstore-read" --strings "%t/name.db" key2 >> "%t/name"
+RUN: echo '.' >>  "%t/name"
+RUN: "%binaries/pstore-read" --strings "%t/name.db" key3 >> "%t/name"
+RUN: echo '.' >>  "%t/name"
+RUN: "%binaries/pstore-read" --strings "%t/name.db" key4 >> "%t/name"
+RUN: echo '.' >>  "%t/name"
+RUN: "%binaries/pstore-read" --strings "%t/name.db" key5 >> "%t/name"
+RUN: echo '.' >>  "%t/name"
 
 # Check that the data made the round trip successfully.
-RUN: diff "%T/name" "%S/name_expected.txt"
+RUN: diff "%t/name" "%S/name_expected.txt"

--- a/system_tests/index/name_and_write.test
+++ b/system_tests/index/name_and_write.test
@@ -1,36 +1,35 @@
-# %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
 
-# Delete an existing data store.
-RUN: rm -f %stores/name_and_write.db
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
+
 
 # Write four values into the data store
-RUN: "%binaries/pstore-write" "--add=key1,value1" "%stores/name_and_write.db"
-RUN: "%binaries/pstore-write" "--add=key2,value2" "%stores/name_and_write.db"
-RUN: "%binaries/pstore-write" "--add-string=key3" "%stores/name_and_write.db"
-RUN: "%binaries/pstore-write" "--add-string=key4" "%stores/name_and_write.db"
+RUN: "%binaries/pstore-write" "--add=key1,value1" "%t/name_and_write.db"
+RUN: "%binaries/pstore-write" "--add=key2,value2" "%t/name_and_write.db"
+RUN: "%binaries/pstore-write" "--add-string=key3" "%t/name_and_write.db"
+RUN: "%binaries/pstore-write" "--add-string=key4" "%t/name_and_write.db"
 
-RUN: echo "%stores"
 # Read the keys and store the resulting data in a file named read
 # in the test output directory
-RUN: "%binaries/pstore-read" "%stores/name_and_write.db" key1 > "%T/name_and_write"
-RUN: echo '.' >>  "%T/name_and_write"
-RUN: "%binaries/pstore-read" "%stores/name_and_write.db" key2 >> "%T/name_and_write"
-RUN: echo '.' >>  "%T/name_and_write"
-RUN: "%binaries/pstore-read" "%stores/name_and_write.db" key3 >> "%T/name_and_write"
-RUN: echo '.' >>  "%T/name_and_write"
-RUN: "%binaries/pstore-read" "%stores/name_and_write.db" key4 >> "%T/name_and_write"
-RUN: echo '.' >>  "%T/name_and_write"
-RUN: "%binaries/pstore-read" --strings "%stores/name_and_write.db" key1 >> "%T/name_and_write"
-RUN: echo '.' >>  "%T/name_and_write"
-RUN: "%binaries/pstore-read" --strings "%stores/name_and_write.db" key2 >> "%T/name_and_write"
-RUN: echo '.' >>  "%T/name_and_write"
-RUN: "%binaries/pstore-read" --strings "%stores/name_and_write.db" key3 >> "%T/name_and_write"
-RUN: echo '.' >>  "%T/name_and_write"
-RUN: "%binaries/pstore-read" --strings "%stores/name_and_write.db" key4 >> "%T/name_and_write"
-RUN: echo '.' >>  "%T/name_and_write"
+RUN: "%binaries/pstore-read" "%t/name_and_write.db" key1 > "%t/name_and_write"
+RUN: echo '.' >>  "%t/name_and_write"
+RUN: "%binaries/pstore-read" "%t/name_and_write.db" key2 >> "%t/name_and_write"
+RUN: echo '.' >>  "%t/name_and_write"
+RUN: "%binaries/pstore-read" "%t/name_and_write.db" key3 >> "%t/name_and_write"
+RUN: echo '.' >>  "%t/name_and_write"
+RUN: "%binaries/pstore-read" "%t/name_and_write.db" key4 >> "%t/name_and_write"
+RUN: echo '.' >>  "%t/name_and_write"
+RUN: "%binaries/pstore-read" --strings "%t/name_and_write.db" key1 >> "%t/name_and_write"
+RUN: echo '.' >>  "%t/name_and_write"
+RUN: "%binaries/pstore-read" --strings "%t/name_and_write.db" key2 >> "%t/name_and_write"
+RUN: echo '.' >>  "%t/name_and_write"
+RUN: "%binaries/pstore-read" --strings "%t/name_and_write.db" key3 >> "%t/name_and_write"
+RUN: echo '.' >>  "%t/name_and_write"
+RUN: "%binaries/pstore-read" --strings "%t/name_and_write.db" key4 >> "%t/name_and_write"
+RUN: echo '.' >>  "%t/name_and_write"
 
 # Check that the data made the round trip successfully.
-RUN: diff "%T/name_and_write" "%S/name_and_write_expected.txt"
+RUN: diff "%t/name_and_write" "%S/name_and_write_expected.txt"

--- a/system_tests/index/put1.test
+++ b/system_tests/index/put1.test
@@ -1,21 +1,23 @@
 # %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %t = temporary file name unique to the test
+
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
+
 
 # Generate test data: a file full of 16-bit big-endian primes.
-RUN: %binaries/pstore-sieve --endian=big -o %T/put1.bin
+RUN: %binaries/pstore-sieve --endian=big -o %t/put1.bin
 
-# Delete an existing data store.
-RUN: rm -f %stores/put1.db
 
 # Copy the put1.bin file into the data store with the key 'p1'
-RUN: "%binaries/pstore-write" "--add-file=p1,%T/put1.bin" "%stores/put1.db"
+RUN: "%binaries/pstore-write" "--add-file=p1,%t/put1.bin" "%t/put1.db"
 
-RUN: echo "%stores"
+
 # Read the 'p1' key and store the resulting data in a file named p1
 # in the test output directory
-RUN: "%binaries/pstore-read" "%stores/put1.db" p1 > "%T/p1"
+RUN: "%binaries/pstore-read" "%t/put1.db" p1 > "%t/p1"
+
 
 # Check that the data made the round trip successfully.
-RUN: diff "%T/p1" "%T/put1.bin"
+RUN: diff "%t/p1" "%t/put1.bin"

--- a/system_tests/index/put2.test
+++ b/system_tests/index/put2.test
@@ -3,41 +3,34 @@
 # original files. All three files are added in a single transaction.
 
 
-# %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
 
 
-# Delete an existing data store (we don't want to end up appending to it)
-RUN: rm -f "%stores/put2.db"
-
-
-# Create a directory to hold the test outputs.
-RUN: rm -r -f "%T/put2"
-RUN: mkdir -p %T/put2
-
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
 
 
 # Generate test data: three files full of 16-bit big-endian primes.
-RUN: "%binaries/pstore-sieve" --endian=big --maximum=100 -o "%T/put2/inp100.bin"
-RUN: "%binaries/pstore-sieve" --endian=big --maximum=1000 -o "%T/put2/inp1000.bin"
-RUN: "%binaries/pstore-sieve" --endian=big --maximum=10000 -o "%T/put2/inp10000.bin"
+RUN: "%binaries/pstore-sieve" --endian=big --maximum=100 -o "%t/inp100.bin"
+RUN: "%binaries/pstore-sieve" --endian=big --maximum=1000 -o "%t/inp1000.bin"
+RUN: "%binaries/pstore-sieve" --endian=big --maximum=10000 -o "%t/inp10000.bin"
 
 
 # Copy the put1.bin file into the data store with the key 'p1'
-RUN: "%binaries/pstore-write" "--add-file=p100,%T/put2/inp100.bin" \
-RUN:                          "--add-file=p1000,%T/put2/inp1000.bin" \
-RUN:                          "--add-file=p10000,%T/put2/inp10000.bin" \
-RUN:                          "%stores/put2.db"
+RUN: "%binaries/pstore-write" "--add-file=p100,%t/inp100.bin" \
+RUN:                          "--add-file=p1000,%t/inp1000.bin" \
+RUN:                          "--add-file=p10000,%t/inp10000.bin" \
+RUN:                          "%t/put2.db"
 
 # Read the threes keys and extract the resulting data in correspondingly named files
 # in the test output directory
-RUN: "%binaries/pstore-read" "%stores/put2.db" p100 > "%T/put2/p100"
-RUN: "%binaries/pstore-read" "%stores/put2.db" p1000 > "%T/put2/p1000"
-RUN: "%binaries/pstore-read" "%stores/put2.db" p10000 > "%T/put2/p10000"
+RUN: "%binaries/pstore-read" "%t/put2.db" p100 > "%t/p100"
+RUN: "%binaries/pstore-read" "%t/put2.db" p1000 > "%t/p1000"
+RUN: "%binaries/pstore-read" "%t/put2.db" p10000 > "%t/p10000"
 
 # Check that the data made the round trip successfully.
-RUN: diff "%T/put2/p100" "%T/put2/inp100.bin"
-RUN: diff "%T/put2/p1000" "%T/put2/inp1000.bin"
-RUN: diff "%T/put2/p10000" "%T/put2/inp10000.bin"
+RUN: diff "%t/p100" "%t/inp100.bin"
+RUN: diff "%t/p1000" "%t/inp1000.bin"
+RUN: diff "%t/p10000" "%t/inp10000.bin"

--- a/system_tests/index/put3.test
+++ b/system_tests/index/put3.test
@@ -3,41 +3,35 @@
 # compared to the originals.
 
 
-# %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
 
 
-# Delete an existing data store (we don't want to end up appending to it)
-RUN: rm -f "%stores/put3.db"
-
-
-# Create a directory to hold the test outputs.
-RUN: rm -r -f "%T/put3"
-RUN: mkdir -p "%T/put3"
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
 
 
 
 # Generate test data: three files full of 16-bit big-endian primes.
-RUN: "%binaries/pstore-sieve" --endian=big --maximum=100 -o "%T/put3/inp100.bin"
-RUN: "%binaries/pstore-sieve" --endian=big --maximum=1000 -o "%T/put3/inp1000.bin"
-RUN: "%binaries/pstore-sieve" --endian=big --maximum=10000 -o "%T/put3/inp10000.bin"
+RUN: "%binaries/pstore-sieve" --endian=big --maximum=100 -o "%t/inp100.bin"
+RUN: "%binaries/pstore-sieve" --endian=big --maximum=1000 -o "%t/inp1000.bin"
+RUN: "%binaries/pstore-sieve" --endian=big --maximum=10000 -o "%t/inp10000.bin"
 
 
 # Run the 'write' utility three times to store the three files with one transaction
 # per run.
-RUN: "%binaries/pstore-write" "--add-file=p100,%T/put3/inp100.bin"     "%stores/put3.db"
-RUN: "%binaries/pstore-write" "--add-file=p1000,%T/put3/inp1000.bin"   "%stores/put3.db"
-RUN: "%binaries/pstore-write" "--add-file=p10000,%T/put3/inp10000.bin" "%stores/put3.db"
+RUN: "%binaries/pstore-write" "--add-file=p100,%t/inp100.bin"     "%t/put3.db"
+RUN: "%binaries/pstore-write" "--add-file=p1000,%t/inp1000.bin"   "%t/put3.db"
+RUN: "%binaries/pstore-write" "--add-file=p10000,%t/inp10000.bin" "%t/put3.db"
 
 # Read the threes keys and extract the resulting data in correspondingly named files
 # in the test output directory
-RUN: "%binaries/pstore-read" "%stores/put3.db" p100 > "%T/put3/p100"
-RUN: "%binaries/pstore-read" "%stores/put3.db" p1000 > "%T/put3/p1000"
-RUN: "%binaries/pstore-read" "%stores/put3.db" p10000 > "%T/put3/p10000"
+RUN: "%binaries/pstore-read" "%t/put3.db" p100 > "%t/p100"
+RUN: "%binaries/pstore-read" "%t/put3.db" p1000 > "%t/p1000"
+RUN: "%binaries/pstore-read" "%t/put3.db" p10000 > "%t/p10000"
 
 # Check that the data made the round trip successfully.
-RUN: diff "%T/put3/p100" "%T/put3/inp100.bin"
-RUN: diff "%T/put3/p1000" "%T/put3/inp1000.bin"
-RUN: diff "%T/put3/p10000" "%T/put3/inp10000.bin"
+RUN: diff "%t/p100" "%t/inp100.bin"
+RUN: diff "%t/p1000" "%t/inp1000.bin"
+RUN: diff "%t/p10000" "%t/inp10000.bin"

--- a/system_tests/index/read_missing_file.test
+++ b/system_tests/index/read_missing_file.test
@@ -1,5 +1,8 @@
 # Try to dump a missing data store.
 XFAIL: *
-RUN: mkdir -p "%T/read_missing_file"
-RUN: "%binaries/pstore-read" "%T/read_missing_file/foo.db"
+
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
+
+RUN: "%binaries/pstore-read" "%t/foo.db"
 

--- a/system_tests/index/write.test
+++ b/system_tests/index/write.test
@@ -1,39 +1,38 @@
-# %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
 
-# Delete an existing data store.
-RUN: rm -f %stores/write.db
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
 
 # Write three values into the data store
-RUN: "%binaries/pstore-write" "--add=k1,value1" "%stores/write.db"
-RUN: "%binaries/pstore-write" "--add=k2,value2" "%stores/write.db"
-RUN: "%binaries/pstore-write" "--add=k3,value3" "%stores/write.db"
+RUN: "%binaries/pstore-write" "--add=k1,value1" "%t/write.db"
+RUN: "%binaries/pstore-write" "--add=k2,value2" "%t/write.db"
+RUN: "%binaries/pstore-write" "--add=k3,value3" "%t/write.db"
 
-RUN: echo "%stores"
+RUN: echo "%t"
 # Read the keys and store the resulting data in a file named write
 # in the test output directory
-RUN: "%binaries/pstore-read" "%stores/write.db" k1 > "%T/write"
-RUN: echo '.' >>  "%T/write"
-RUN: "%binaries/pstore-read" "%stores/write.db" k2 >> "%T/write"
-RUN: echo '.' >>  "%T/write"
-RUN: "%binaries/pstore-read" "%stores/write.db" k3 >> "%T/write"
-RUN: echo '.' >>  "%T/write"
-RUN: "%binaries/pstore-read" "%stores/write.db" k4 >> "%T/write"
-RUN: echo '.' >>  "%T/write"
-RUN: "%binaries/pstore-read" "%stores/write.db" k5 >> "%T/write"
-RUN: echo '.' >>  "%T/write"
+RUN: "%binaries/pstore-read" "%t/write.db" k1 > "%t/write"
+RUN: echo '.' >>  "%t/write"
+RUN: "%binaries/pstore-read" "%t/write.db" k2 >> "%t/write"
+RUN: echo '.' >>  "%t/write"
+RUN: "%binaries/pstore-read" "%t/write.db" k3 >> "%t/write"
+RUN: echo '.' >>  "%t/write"
+RUN: "%binaries/pstore-read" "%t/write.db" k4 >> "%t/write"
+RUN: echo '.' >>  "%t/write"
+RUN: "%binaries/pstore-read" "%t/write.db" k5 >> "%t/write"
+RUN: echo '.' >>  "%t/write"
 
 # Write a new values into the data store
-RUN: "%binaries/pstore-write" "--add=k1,new_value1" "%stores/write.db"
+RUN: "%binaries/pstore-write" "--add=k1,new_value1" "%t/write.db"
 
 # Read the key and store the resulting data in a file named write
 # in the test output directory
-RUN: "%binaries/pstore-read" "%stores/write.db" k1 >> "%T/write"
-RUN: echo '.' >>  "%T/write"
-RUN: "%binaries/pstore-read" "-r" "1" "%stores/write.db" k1 >> "%T/write"
-RUN: echo '.' >>  "%T/write"
+RUN: "%binaries/pstore-read" "%t/write.db" k1 >> "%t/write"
+RUN: echo '.' >>  "%t/write"
+RUN: "%binaries/pstore-read" "-r" "1" "%t/write.db" k1 >> "%t/write"
+RUN: echo '.' >>  "%t/write"
 
 # Check that the data made the round trip successfully.
-RUN: diff "%T/write" "%S/write_expected.txt"
+RUN: diff "%t/write" "%S/write_expected.txt"

--- a/system_tests/locking/locking.test
+++ b/system_tests/locking/locking.test
@@ -1,8 +1,7 @@
 # %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %t = temporary file name unique to the test
 
 # Delete an existing data store.
-RUN: rm -f "%stores/locking.db"
-RUN: %python "%S/locking.py" "%binaries" "%stores/locking.db"
+RUN: rm -f "%t"
+RUN: %python "%S/locking.py" "%binaries" "%t"

--- a/system_tests/read_and_write/read_and_write.test
+++ b/system_tests/read_and_write/read_and_write.test
@@ -1,12 +1,11 @@
 # %binaries = the directories containing the executable binaries
-# %stores = a directory in which data stores may be created
-# %T = the test output directory
 # %S = the test source directory
+# %t = temporary file name unique to the test
 
-RUN: rm -f "%T/pstore.db"
-RUN: "%binaries/pstore-write" --add mykey,foo "%T/pstore.db"
-RUN: "%binaries/pstore-read" "%T/pstore.db" mykey > "%T/out.txt"
-RUN: "%binaries/pstore-write" --add mykey,bar "%T/pstore.db"
-RUN: "%binaries/pstore-read" "%T/pstore.db" mykey >> "%T/out.txt"
-RUN: "%binaries/pstore-read" -r 1 "%T/pstore.db" mykey >> "%T/out.txt"
-RUN: diff -w "%S/expected.txt" "%T/out.txt"
+RUN: rm -rf "%t" && mkdir -p "%t"
+RUN: "%binaries/pstore-write" --add mykey,foo "%t/pstore.db"
+RUN: "%binaries/pstore-read" "%t/pstore.db" mykey > "%t/out.txt"
+RUN: "%binaries/pstore-write" --add mykey,bar "%t/pstore.db"
+RUN: "%binaries/pstore-read" "%t/pstore.db" mykey >> "%t/out.txt"
+RUN: "%binaries/pstore-read" -r 1 "%t/pstore.db" mykey >> "%t/out.txt"
+RUN: diff -w "%S/expected.txt" "%t/out.txt"

--- a/system_tests/serialize/ex1.t
+++ b/system_tests/serialize/ex1.t
@@ -1,6 +1,7 @@
-# %binaries = the directories containing the executable binaries
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
+
 REQUIRES: examples
-RUN: %binaries/example-write-integers > %T/ex1_actual.txt
-RUN: diff %T/ex1_actual.txt %S/ex1_expected.txt
+RUN: "%binaries/example-write-integers" > "%t"
+RUN: diff "%t" "%S/ex1_expected.txt"

--- a/system_tests/serialize/ex2.t
+++ b/system_tests/serialize/ex2.t
@@ -1,6 +1,11 @@
 # %binaries = the directories containing the executable binaries
-# %T = the test output directory
 # %S = the test source directory
+# %t = temporary file name unique to the test
+
 REQUIRES: examples
-RUN: %binaries/example-write-pod-struct > %T/ex2_actual.txt
-RUN: diff %T/ex2_actual.txt %S/ex2_expected.txt
+
+# Delete any existing results.
+RUN: rm -rf "%t" && mkdir -p "%t"
+
+RUN: %binaries/example-write-pod-struct > "%t/ex2_actual.txt"
+RUN: diff "%t/ex2_actual.txt" "%S/ex2_expected.txt"

--- a/system_tests/serialize/istream_reader.t
+++ b/system_tests/serialize/istream_reader.t
@@ -1,6 +1,7 @@
-# %binaries = the directories containing the executable binaries
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
+
 REQUIRES: examples
-RUN: %binaries/example-istream-reader > %T/istream_reader_actual.txt
-RUN: diff %T/istream_reader_actual.txt %S/istream_reader_expected.txt
+RUN: "%binaries/example-istream-reader" > "%t"
+RUN: diff "%t" "%S/istream_reader_expected.txt"

--- a/system_tests/serialize/nonpod1.t
+++ b/system_tests/serialize/nonpod1.t
@@ -1,6 +1,7 @@
-# %binaries = the directories containing the executable binaries
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
+
 REQUIRES: examples
-RUN: %binaries/example-nonpod1 > %T/nonpod1_actual.txt
-RUN: diff %T/nonpod1_actual.txt %S/nonpod1_expected.txt
+RUN: "%binaries/example-nonpod1" > "%t"
+RUN: diff "%t" "%S/nonpod1_expected.txt"

--- a/system_tests/serialize/nonpod2.t
+++ b/system_tests/serialize/nonpod2.t
@@ -1,6 +1,8 @@
-# %binaries = the directories containing the executable binaries
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
+
 REQUIRES: examples
-RUN: %binaries/example-nonpod2 > %T/nonpod2_actual.txt
-RUN: diff %T/nonpod2_actual.txt %S/nonpod2_expected.txt
+
+RUN: "%binaries/example-nonpod2" > "%t"
+RUN: diff "%t" "%S/nonpod2_expected.txt"

--- a/system_tests/serialize/ostream_writer.t
+++ b/system_tests/serialize/ostream_writer.t
@@ -1,6 +1,8 @@
-# %binaries = the directories containing the executable binaries
-# %T = the test output directory
 # %S = the test source directory
+# %binaries = the directories containing the executable binaries
+# %t = temporary file name unique to the test
+
 REQUIRES: examples
-RUN: %binaries/example-ostream-writer > %T/ostream_writer_actual.txt
-RUN: diff %T/ostream_writer_actual.txt %S/ostream_writer_expected.txt
+
+RUN: "%binaries/example-ostream-writer" > "%t"
+RUN: diff "%t" "%S/ostream_writer_expected.txt"


### PR DESCRIPTION
At some point the LIT “%T” substitution was deprecated (see the [documentation](https://llvm.org/docs/CommandGuide/lit.html)). This change eliminates its use entirely from the pstore system tests to ensure that a future update to LIT doesn’t introduce unexpected failures.

In cases where we only need one file, I use %t as the file path; where I need a directory with multiple files, I `mkdir %t` and use that.

%stores was introduced a long time ago because I used a VM host that didn’t support memory mapped files on a network volume. The config code set it up to point to a location that did support them. This limitation has now gone away so its use has become inconsistent. It has been removed from the tests.