### PR TITLE
Fix for an empty index header block being written.

### DIFF
--- a/unittests/core/test_hamt_map.cpp
+++ b/unittests/core/test_hamt_map.cpp
@@ -410,10 +410,11 @@ TEST_F (HamtRoundTrip, Empty) {
     index_type index1{*db_, pstore::typed_address<pstore::index::header_block>::null ()};
     {
         auto t1 = begin (*db_, std::unique_lock<mock_mutex>{mutex_});
+        auto const size_before_flush = db_->size ();
         addr = index1.flush (t1, db_->get_current_revision ());
+        EXPECT_EQ (db_->size (), size_before_flush);
         t1.commit ();
     }
-
     index_type index2{*db_, addr};
     EXPECT_EQ (index2.size (), 0U);
 }


### PR DESCRIPTION
A fix for issue #57. This behavior gained slightly more significance when comparing the files produced by pstore-import with their originals in order to verify that all of the data is making the round-trip intact.

After this fix, the commands shown in the description of #57 produce the desired output:

~~~bash
% rm db.db ; pstore-write db.db hello.txt ; pstore-index-stats db.db
name,branching-factor,mean-leaf-depth,max-depth,size
write,0,1,1,1
% 
~~~
(The ‘name’ index is no longer listed because there is no header block indicating to [pstore-index-stats](https://github.com/SNSystems/pstore/tree/master/tools/index_stats) that the index has members.)