### PR TITLE
Define an enum for reference strength

### DIFF
--- a/include/pstore/mcrepo/generic_section.hpp
+++ b/include/pstore/mcrepo/generic_section.hpp
@@ -92,6 +92,13 @@ namespace pstore {
 
         std::ostream & operator<< (std::ostream & os, internal_fixup const & xfx);
 
+        /// Defines the strength of an external reference. A "strong" reference must be resolved
+        /// whereas a link with unresolved weak references will complete successfully.
+        enum class reference_strength {
+            strong,
+            weak,
+        };
+
         //*          _                     _    __ _                *
         //*  _____ _| |_ ___ _ _ _ _  __ _| |  / _(_)_ ___  _ _ __  *
         //* / -_) \ /  _/ -_) '_| ' \/ _` | | |  _| \ \ / || | '_ \ *
@@ -110,12 +117,13 @@ namespace pstore {
                     , addend{addend_} {}
 #endif // PSTORE_IS_INSIDE_LLVM
             constexpr external_fixup (typed_address<indirect_string> const name_,
-                                      relocation_type const type_, bool const is_weak_,
+                                      relocation_type const type_,
+                                      reference_strength const strength,
                                       std::uint64_t const offset_,
                                       std::int64_t const addend_) noexcept
                     : name{name_}
                     , type{type_}
-                    , is_weak{is_weak_}
+                    , is_weak{strength == reference_strength::weak}
                     , offset{offset_}
                     , addend{addend_} {}
 

--- a/lib/exchange/import_fixups.cpp
+++ b/lib/exchange/import_fixups.cpp
@@ -152,7 +152,9 @@ namespace pstore {
                 }
 
                 // TODO: validate some values here.
-                fixups_->emplace_back (*name, static_cast<repo::relocation_type> (type_), is_weak_,
+                fixups_->emplace_back (*name, static_cast<repo::relocation_type> (type_),
+                                       is_weak_ ? repo::reference_strength::weak
+                                                : repo::reference_strength::strong,
                                        offset_, addend_);
                 return pop ();
             }

--- a/unittests/dump/test_mcrepo.cpp
+++ b/unittests/dump/test_mcrepo.cpp
@@ -148,8 +148,11 @@ TEST_F (MCRepoFixture, DumpFragment) {
     {
         // Build the data section's contents and fixups.
         data.data.assign ({'t', 'e', 'x', 't'});
-        data.ifixups.emplace_back (internal_fixup{section_kind::data, 2, 2, 2});
-        data.xfixups.emplace_back (external_fixup{name, 3, false /*is_weak*/, 3, 3});
+        data.ifixups.emplace_back (internal_fixup{section_kind::data, relocation_type{2},
+                                                  UINT64_C (2) /*offset*/, INT64_C (2) /*addend*/});
+        data.xfixups.emplace_back (external_fixup{name, relocation_type{3},
+                                                  pstore::repo::reference_strength::strong,
+                                                  UINT64_C (3) /*offset*/, INT32_C (3) /*addend*/});
     }
 
     // Build the definition for 'foo'

--- a/unittests/exchange/test_generic_section.cpp
+++ b/unittests/exchange/test_generic_section.cpp
@@ -137,10 +137,12 @@ TEST_F (GenericSection, RoundTripForPopulated) {
         pstore::repo::section_kind::read_only, pstore::repo::relocation_type{11},
         std::uint64_t{13} /*offset*/, std::int64_t{17} /*addend*/);
     exported_content.xfixups.emplace_back (indir_strings[name1], pstore::repo::relocation_type{19},
-                                           false /*is_weak*/, std::uint64_t{23} /*offset*/,
+                                           pstore::repo::reference_strength::strong,
+                                           std::uint64_t{23} /*offset*/,
                                            std::int64_t{29} /*addend*/);
     exported_content.xfixups.emplace_back (indir_strings[name2], pstore::repo::relocation_type{31},
-                                           true /*is_weak*/, std::uint64_t{37} /*offset*/,
+                                           pstore::repo::reference_strength::weak,
+                                           std::uint64_t{37} /*offset*/,
                                            std::int64_t{41} /*addend*/);
 
 

--- a/unittests/exchange/test_section_fixups.cpp
+++ b/unittests/exchange/test_section_fixups.cpp
@@ -361,9 +361,9 @@ TEST_F (ExchangeExternalFixups, RoundTripForTwoFixups) {
     // add_export_strings().
     xfixup_collection xfixups;
     xfixups.emplace_back (indir_strings["foo"], static_cast<pstore::repo::relocation_type> (5),
-                          false /*is_weak*/, 7, 9);
+                          pstore::repo::reference_strength::strong, 7, 9);
     xfixups.emplace_back (indir_strings["bar"], static_cast<pstore::repo::relocation_type> (11),
-                          true /*is_weak*/, 13, 17);
+                          pstore::repo::reference_strength::weak, 13, 17);
 
 
 

--- a/unittests/mcrepo/test_fragment.cpp
+++ b/unittests/mcrepo/test_fragment.cpp
@@ -143,12 +143,15 @@ TEST_F (FragmentTest, MakeTextSectionWithFixups) {
         text.data.assign (std::begin (original), std::end (original));
         text.ifixups.emplace_back (internal_fixup{section_kind::text, 1, 1, 1});
         text.ifixups.emplace_back (internal_fixup{section_kind::data, 2, 2, 2});
-        text.xfixups.emplace_back (
-            external_fixup{indirect_string_address (3), 3, false /*is_weak*/, 3, 3});
-        text.xfixups.emplace_back (
-            external_fixup{indirect_string_address (4), 4, true /*is_weak*/, 4, 4});
-        text.xfixups.emplace_back (
-            external_fixup{indirect_string_address (5), 5, false /*is_weak*/, 5, 5});
+        text.xfixups.emplace_back (external_fixup{indirect_string_address (3), relocation_type{3},
+                                                  pstore::repo::reference_strength::strong,
+                                                  UINT64_C (3) /*offset*/, INT64_C (3) /*addend*/});
+        text.xfixups.emplace_back (external_fixup{indirect_string_address (4), relocation_type{4},
+                                                  pstore::repo::reference_strength::weak,
+                                                  UINT64_C (4) /*offset*/, INT64_C (4) /*addend*/});
+        text.xfixups.emplace_back (external_fixup{indirect_string_address (5), relocation_type{5},
+                                                  pstore::repo::reference_strength::strong,
+                                                  UINT64_C (5) /*offset*/, INT64_C (5) /*addend*/});
     }
 
     auto extent = build_fragment (transaction_, std::begin (c), std::end (c));
@@ -179,11 +182,16 @@ TEST_F (FragmentTest, MakeTextSectionWithFixups) {
     EXPECT_THAT (s.payload (), ElementsAreArray (original));
     EXPECT_THAT (s.ifixups (), ElementsAre (internal_fixup{section_kind::text, 1, 1, 1},
                                             internal_fixup{section_kind::data, 2, 2, 2}));
-    EXPECT_THAT (
-        s.xfixups (),
-        ElementsAre (external_fixup{indirect_string_address (3), 3, false /*is_weak*/, 3, 3},
-                     external_fixup{indirect_string_address (4), 4, true /*is_weak*/, 4, 4},
-                     external_fixup{indirect_string_address (5), 5, false /*is_weak*/, 5, 5}));
+    EXPECT_THAT (s.xfixups (),
+                 ElementsAre (external_fixup{indirect_string_address (3), relocation_type{3},
+                                             pstore::repo::reference_strength::strong,
+                                             UINT64_C (3) /*offset*/, INT64_C (3) /*addend*/},
+                              external_fixup{indirect_string_address (4), relocation_type{4},
+                                             pstore::repo::reference_strength::weak,
+                                             UINT64_C (4) /*offset*/, INT64_C (4) /*addend*/},
+                              external_fixup{indirect_string_address (5), relocation_type{5},
+                                             pstore::repo::reference_strength::strong,
+                                             UINT64_C (5) /*offset*/, INT64_C (5) /*addend*/}));
 }
 
 TEST_F (FragmentTest, MakeTextSectionWithLinkedDefinitions) {


### PR DESCRIPTION
Part of the continuing work for [prepo issue #139](https://github.com/SNSystems/llvm-project-prepo/issues/139).

The arguments used to build an external references have become rather hard to read: passing a collection of numbers and now an extra bool are all fairly meaningless.

Rather than passing a simple bool to the `external_fixup` ctor, we now use an enum with explicit names for “weak” and “strong” references.