### PR TITLE
Reliably record ticket file directories for repository GC

### DIFF
--- a/include/pstore/core/database.hpp
+++ b/include/pstore/core/database.hpp
@@ -39,7 +39,7 @@ namespace pstore {
 
     class database {
     public:
-        enum class access_mode { read_only, writable };
+        enum class access_mode { read_only, writable, writeable_no_create };
 
         /// Creates a database instance give the path of the file to use.
         ///

--- a/include/pstore/core/file_header.hpp
+++ b/include/pstore/core/file_header.hpp
@@ -93,7 +93,7 @@ namespace pstore {
         std::array<std::uint16_t, 2> const & version () const noexcept { return a.version; }
 
         static constexpr std::uint16_t major_version = 1;
-        static constexpr std::uint16_t minor_version = 10;
+        static constexpr std::uint16_t minor_version = 11;
 
         static std::array<std::uint8_t, 4> const file_signature1;
         static std::uint32_t const file_signature2 = 0x0507FFFF;
@@ -138,6 +138,8 @@ namespace pstore {
         std::atomic<typed_address<trailer>> footer_pos;
     };
 
+    // Assert the size, offset, and alignment of the structure and its fields to ensure file format
+    // compatibility across compilers and hosts.
     PSTORE_STATIC_ASSERT (offsetof (header::body, signature1) == 0);
     PSTORE_STATIC_ASSERT (offsetof (header::body, signature2) == 4);
     PSTORE_STATIC_ASSERT (offsetof (header::body, version) == 8);
@@ -171,6 +173,8 @@ namespace pstore {
         }
     };
 
+    // Assert the size, offset, and alignment of the structure and its fields to ensure file format
+    // compatibility across compilers and hosts.
     PSTORE_STATIC_ASSERT (offsetof (lock_block, vacuum_lock) == 0);
     PSTORE_STATIC_ASSERT (offsetof (lock_block, transaction_lock) == 8);
     PSTORE_STATIC_ASSERT (alignof (lock_block) == 8);
@@ -187,6 +191,7 @@ namespace pstore {
     X (debug_line_header)                                                                          \
     X (fragment)                                                                                   \
     X (name)                                                                                       \
+    X (path)                                                                                       \
     X (write)
 
         struct header_block;
@@ -258,6 +263,8 @@ namespace pstore {
         std::array<std::uint8_t, 8> signature2 = default_signature2;
     };
 
+    // Assert the size, offset, and alignment of the structure and its fields to ensure file format
+    // compatibility across compilers and hosts.
     PSTORE_STATIC_ASSERT (offsetof (trailer::body, signature1) == 0);
     PSTORE_STATIC_ASSERT (offsetof (trailer::body, generation) == 8);
     PSTORE_STATIC_ASSERT (offsetof (trailer::body, unused1) == 12);
@@ -265,15 +272,16 @@ namespace pstore {
     PSTORE_STATIC_ASSERT (offsetof (trailer::body, time) == 24);
     PSTORE_STATIC_ASSERT (offsetof (trailer::body, prev_generation) == 32);
     PSTORE_STATIC_ASSERT (offsetof (trailer::body, index_records) == 40);
-    PSTORE_STATIC_ASSERT (offsetof (trailer::body, unused2) == 80);
-    PSTORE_STATIC_ASSERT (offsetof (trailer::body, unused3) == 84);
-    PSTORE_STATIC_ASSERT (sizeof (trailer::body) == 88);
+    PSTORE_STATIC_ASSERT (offsetof (trailer::body, unused2) == 88);
+    PSTORE_STATIC_ASSERT (offsetof (trailer::body, unused3) == 92);
+    PSTORE_STATIC_ASSERT (alignof (trailer::body) == 8);
+    PSTORE_STATIC_ASSERT (sizeof (trailer::body) == 96);
 
     PSTORE_STATIC_ASSERT (offsetof (trailer, a) == 0);
-    PSTORE_STATIC_ASSERT (offsetof (trailer, crc) == 88);
-    PSTORE_STATIC_ASSERT (offsetof (trailer, signature2) == 96);
+    PSTORE_STATIC_ASSERT (offsetof (trailer, crc) == 96);
+    PSTORE_STATIC_ASSERT (offsetof (trailer, signature2) == 104);
     PSTORE_STATIC_ASSERT (alignof (trailer) == 8);
-    PSTORE_STATIC_ASSERT (sizeof (trailer) == 104);
+    PSTORE_STATIC_ASSERT (sizeof (trailer) == 112);
 
 } // namespace pstore
 #endif // PSTORE_CORE_FILE_HEADER_HPP

--- a/include/pstore/core/index_types.hpp
+++ b/include/pstore/core/index_types.hpp
@@ -103,17 +103,19 @@ namespace pstore {
         };
 
         using name_index = hamt_set<indirect_string, fnv_64a_hash_indirect_string>;
+        using path_index = hamt_set<indirect_string, fnv_64a_hash_indirect_string>;
 
         // clang-format off
         /// Maps from the indices kind enumeration to the type that is used to represent a database index of that kind.
         template <trailer::indices T>
         struct enum_to_index {};
 
-        template <> struct enum_to_index<trailer::indices::compilation         > { using type = compilation_index; };
-        template <> struct enum_to_index<trailer::indices::debug_line_header   > { using type = debug_line_header_index; };
-        template <> struct enum_to_index<trailer::indices::fragment            > { using type = fragment_index; };
-        template <> struct enum_to_index<trailer::indices::name                > { using type = name_index; };
-        template <> struct enum_to_index<trailer::indices::write               > { using type = write_index; };
+        template <> struct enum_to_index<trailer::indices::compilation      > { using type = compilation_index;       };
+        template <> struct enum_to_index<trailer::indices::debug_line_header> { using type = debug_line_header_index; };
+        template <> struct enum_to_index<trailer::indices::fragment         > { using type = fragment_index;          };
+        template <> struct enum_to_index<trailer::indices::name             > { using type = name_index;              };
+        template <> struct enum_to_index<trailer::indices::path             > { using type = path_index;              };
+        template <> struct enum_to_index<trailer::indices::write            > { using type = write_index;             };
         // clang-format on
 
         /// Returns a pointer to a index, loading it from the store on first access. If 'create' is

--- a/include/pstore/exchange/export_names.hpp
+++ b/include/pstore/exchange/export_names.hpp
@@ -29,15 +29,15 @@ namespace pstore {
             class ostream_base;
 
             template <typename trailer::indices Index>
-            struct index_tag_ {
+            struct index_tag {
                 static constexpr auto index = Index;
             };
 
             inline constexpr decltype (auto) name_index_tag () noexcept {
-                return index_tag_<pstore::trailer::indices::name>{};
+                return index_tag<pstore::trailer::indices::name>{};
             }
             inline constexpr decltype (auto) path_index_tag () noexcept {
-                return index_tag_<pstore::trailer::indices::path>{};
+                return index_tag<pstore::trailer::indices::path>{};
             }
 
 
@@ -46,13 +46,13 @@ namespace pstore {
             //* | ' \/ _` | '  \/ -_) | '  \/ _` | '_ \ '_ \ | ' \/ _` | *
             //* |_||_\__,_|_|_|_\___| |_|_|_\__,_| .__/ .__/_|_||_\__, | *
             //*                                  |_|  |_|         |___/  *
-            /// The name_mapping call is used to associate the addresses of a set of strings with an
-            /// index in the exported names array. The enables the exported JSON to simply reference
-            /// a string by index rather than having to emit the string each time.
+            /// The name_mapping class is used to associate the addresses of a set of strings with
+            /// an index in the exported names array. The enables the exported JSON to simply
+            /// reference a string by index rather than having to emit the string each time.
             class name_mapping {
             public:
                 template <typename trailer::indices Index>
-                name_mapping (database const & db, index_tag_<Index>) {
+                name_mapping (database const & db, index_tag<Index>) {
                     auto const index = index::get_index<Index> (db);
                     names_.reserve (index->size ());
                 }

--- a/include/pstore/exchange/export_names.hpp
+++ b/include/pstore/exchange/export_names.hpp
@@ -28,6 +28,19 @@ namespace pstore {
 
             class ostream_base;
 
+            template <typename trailer::indices Index>
+            struct index_tag_ {
+                static constexpr auto index = Index;
+            };
+
+            inline constexpr decltype (auto) name_index_tag () noexcept {
+                return index_tag_<pstore::trailer::indices::name>{};
+            }
+            inline constexpr decltype (auto) path_index_tag () noexcept {
+                return index_tag_<pstore::trailer::indices::path>{};
+            }
+
+
             //*                                             _            *
             //*  _ _  __ _ _ __  ___   _ __  __ _ _ __ _ __(_)_ _  __ _  *
             //* | ' \/ _` | '  \/ -_) | '  \/ _` | '_ \ '_ \ | ' \/ _` | *
@@ -38,13 +51,20 @@ namespace pstore {
             /// a string by index rather than having to emit the string each time.
             class name_mapping {
             public:
-                explicit name_mapping (database const & db);
+                template <typename trailer::indices Index>
+                name_mapping (database const & db, index_tag_<Index>) {
+                    auto const index = index::get_index<Index> (db);
+                    names_.reserve (index->size ());
+                }
 
                 /// Record the address of a string at \p addr and assign it the next index in in the
                 /// exported names array.
                 ///
-                /// \param addr The address of a string beging exported.
+                /// \param addr The address of a string being exported.
                 void add (address addr);
+
+                /// Returns the number of known addresss to index mappings.
+                std::size_t size () const noexcept { return names_.size (); }
 
                 /// Convert the address of the string at \p addr to the corresponding index in the
                 /// exported names array.
@@ -57,22 +77,56 @@ namespace pstore {
                 std::unordered_map<address, std::uint64_t> names_;
             };
 
-            //*            _ _                             *
-            //*  ___ _ __ (_) |_   _ _  __ _ _ __  ___ ___ *
-            //* / -_) '  \| |  _| | ' \/ _` | '  \/ -_|_-< *
-            //* \___|_|_|_|_|\__| |_||_\__,_|_|_|_\___/__/ *
-            //*                                            *
-            /// Writes the array of names defined in transaction \p generation to output stream
-            /// \p os.
+            //*            _ _        _       _               *
+            //*  ___ _ __ (_) |_   __| |_ _ _(_)_ _  __ _ ___ *
+            //* / -_) '  \| |  _| (_-<  _| '_| | ' \/ _` (_-< *
+            //* \___|_|_|_|_|\__| /__/\__|_| |_|_||_\__, /__/ *
+            //*                                     |___/     *
+            /// Writes the array of strings added to the index given by \p Index in transaction \p
+            /// generation to the output stream \p os.
             ///
+            /// \tparam Index  The index in which the strings are defined.
             /// \p os  The stream to which output is written.
             /// \p ind  The indentation of the output.
             /// \p db  The database instance whose strings are to be dumped.
             /// \p generation  The database generation number whose strings are to be dumped.
             /// \p string_table  The string table accumulates the address-to-index mapping of each
-            /// string as it is dumped.
-            void emit_names (ostream_base & os, indent ind, database const & db,
-                             unsigned const generation, name_mapping * const string_table);
+            ///   string as it is dumped.
+            template <typename trailer::indices Index>
+            void emit_strings (ostream_base & os, indent const ind, database const & db,
+                               unsigned const generation, name_mapping * const string_table) {
+                if (generation == 0U) {
+                    os << "[]";
+                    return;
+                }
+                auto const names_index = index::get_index<Index> (db, false /*create*/);
+                if (names_index == nullptr) {
+                    os << "[]";
+                    return;
+                }
+
+                auto const * separator = "";
+                auto const * tail_separator = "";
+                auto close_bracket_indent = indent{};
+
+                auto const member_indent = ind.next ();
+                auto const out_fn = [&] (pstore::address const addr) {
+                    os << separator << '\n' << member_indent;
+                    {
+                        indirect_string const str = names_index->load_leaf_node (db, addr);
+                        shared_sstring_view owner;
+                        raw_sstring_view const view = str.as_db_string_view (&owner);
+                        emit_string (os, view);
+                        string_table->add (addr);
+                    }
+                    separator = ",";
+                    tail_separator = "\n";
+                    close_bracket_indent = ind;
+                };
+                os << '[';
+                diff (db, *names_index, generation - 1U, make_diff_out (&out_fn));
+                os << tail_separator << close_bracket_indent << ']';
+            }
 
         } // end namespace export_ns
     }     // end namespace exchange

--- a/include/pstore/exchange/export_paths.hpp
+++ b/include/pstore/exchange/export_paths.hpp
@@ -1,0 +1,18 @@
+#ifndef PSTORE_EXCHANGE_EXPORT_PATHS_HPP
+#define PSTORE_EXCHANGE_EXPORT_PATHS_HPP
+
+#include "pstore/exchange/export_names.hpp"
+
+namespace pstore {
+    namespace exchange {
+        namespace export_ns {
+
+            void emit_paths (ostream_base & os, indent const ind, database const & db,
+                             unsigned const generation,
+                             gsl::not_null<name_mapping *> const string_table);
+
+        } // end namespace export_ns
+    }     // end namespace exchange
+} // namespace pstore
+
+#endif // PSTORE_EXCHANGE_EXPORT_PATHS_HPP

--- a/include/pstore/exchange/export_paths.hpp
+++ b/include/pstore/exchange/export_paths.hpp
@@ -1,3 +1,18 @@
+//===- include/pstore/exchange/export_paths.hpp -----------*- mode: C++ -*-===//
+//*                             _                 _   _          *
+//*   _____  ___ __   ___  _ __| |_   _ __   __ _| |_| |__  ___  *
+//*  / _ \ \/ / '_ \ / _ \| '__| __| | '_ \ / _` | __| '_ \/ __| *
+//* |  __/>  <| |_) | (_) | |  | |_  | |_) | (_| | |_| | | \__ \ *
+//*  \___/_/\_\ .__/ \___/|_|   \__| | .__/ \__,_|\__|_| |_|___/ *
+//*           |_|                    |_|                         *
+//===----------------------------------------------------------------------===//
+//
+// Part of the pstore project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://github.com/SNSystems/pstore/blob/master/LICENSE.txt for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
 #ifndef PSTORE_EXCHANGE_EXPORT_PATHS_HPP
 #define PSTORE_EXCHANGE_EXPORT_PATHS_HPP
 

--- a/include/pstore/exchange/export_paths.hpp
+++ b/include/pstore/exchange/export_paths.hpp
@@ -13,6 +13,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+/// \file export_paths.hpp
+/// \brief  Exporting the members of the paths index.
+
 #ifndef PSTORE_EXCHANGE_EXPORT_PATHS_HPP
 #define PSTORE_EXCHANGE_EXPORT_PATHS_HPP
 

--- a/include/pstore/exchange/import_compilation.hpp
+++ b/include/pstore/exchange/import_compilation.hpp
@@ -139,10 +139,9 @@ namespace pstore {
                 fragment_index_pointer const fragments_;
                 index::digest const digest_;
 
-                enum { path_index, triple_index };
+                enum { triple_index };
                 std::bitset<triple_index + 1> seen_;
 
-                std::uint64_t path_ = 0;
                 std::uint64_t triple_ = 0;
                 definition::container definitions_;
             };

--- a/include/pstore/exchange/import_names.hpp
+++ b/include/pstore/exchange/import_names.hpp
@@ -54,6 +54,10 @@ namespace pstore {
                 void flush (not_null<transaction_base *> transaction);
 
                 error_or<typed_address<indirect_string>> lookup (std::uint64_t index) const;
+                std::size_t size () const noexcept {
+                    PSTORE_ASSERT (strings_.size () == views_.size ());
+                    return strings_.size ();
+                }
 
             private:
                 indirect_string_adder adder_;

--- a/include/pstore/exchange/import_transaction.hpp
+++ b/include/pstore/exchange/import_transaction.hpp
@@ -35,10 +35,12 @@ namespace pstore {
             class transaction_contents final : public rule {
             public:
                 transaction_contents (not_null<context *> const ctxt,
-                                      not_null<name_mapping *> const names)
+                                      not_null<name_mapping *> const names,
+                                      not_null<name_mapping *> const paths)
                         : rule (ctxt)
                         , transaction_{begin (*ctxt->db)}
-                        , names_{names} {}
+                        , names_{names}
+                        , paths_{paths} {}
                 transaction_contents (transaction_contents const &) = delete;
                 transaction_contents (transaction_contents &&) noexcept = delete;
 
@@ -56,6 +58,7 @@ namespace pstore {
 
                 transaction<TransactionLock> transaction_;
                 not_null<name_mapping *> names_;
+                not_null<name_mapping *> paths_;
             };
 
             // name
@@ -72,6 +75,9 @@ namespace pstore {
                 // TODO: check that "names" is the first key that we see.
                 if (s == "names") {
                     return push_array_rule<names_array_members> (this, &transaction_, names_);
+                }
+                if (s == "paths") {
+                    return push_array_rule<names_array_members> (this, &transaction_, paths_);
                 }
                 if (s == "debugline") {
                     return push_object_rule<debug_line_index> (this, &transaction_);
@@ -109,9 +115,11 @@ namespace pstore {
             class transaction_object final : public rule {
             public:
                 transaction_object (not_null<context *> const ctxt,
-                                    not_null<name_mapping *> const names)
+                                    not_null<name_mapping *> const names,
+                                    not_null<name_mapping *> const paths)
                         : rule (ctxt)
-                        , names_{names} {}
+                        , names_{names}
+                        , paths_{paths} {}
                 transaction_object (transaction_object const &) = delete;
                 transaction_object (transaction_object &&) noexcept = delete;
 
@@ -124,12 +132,13 @@ namespace pstore {
                     return "transaction object";
                 }
                 std::error_code begin_object () override {
-                    return push<transaction_contents<TransactionLock>> (names_);
+                    return push<transaction_contents<TransactionLock>> (names_, paths_);
                 }
                 std::error_code end_array () override { return pop (); }
 
             private:
                 not_null<name_mapping *> const names_;
+                not_null<name_mapping *> const paths_;
             };
 
             //*  _                             _   _                                    *
@@ -140,7 +149,8 @@ namespace pstore {
             template <typename TransactionLock>
             class transaction_array final : public rule {
             public:
-                transaction_array (not_null<context *> ctxt, not_null<name_mapping *> names);
+                transaction_array (not_null<context *> ctxt, not_null<name_mapping *> names,
+                                   not_null<name_mapping *> paths);
                 transaction_array (transaction_array const &) = delete;
                 transaction_array (transaction_array &&) noexcept = delete;
 
@@ -154,15 +164,18 @@ namespace pstore {
 
             private:
                 not_null<name_mapping *> const names_;
+                not_null<name_mapping *> const paths_;
             };
 
             // (ctor)
             // ~~~~~~
             template <typename TransactionLock>
-            transaction_array<TransactionLock>::transaction_array (
-                not_null<context *> const ctxt, not_null<name_mapping *> const names)
+            transaction_array<TransactionLock>::transaction_array (not_null<context *> ctxt,
+                                                                   not_null<name_mapping *> names,
+                                                                   not_null<name_mapping *> paths)
                     : rule (ctxt)
-                    , names_{names} {}
+                    , names_{names}
+                    , paths_{paths} {}
 
             // name
             // ~~~~
@@ -175,7 +188,7 @@ namespace pstore {
             // ~~~~~~~~~~~
             template <typename TransactionLock>
             std::error_code transaction_array<TransactionLock>::begin_array () {
-                return this->replace_top<transaction_object<TransactionLock>> (names_);
+                return this->replace_top<transaction_object<TransactionLock>> (names_, paths_);
             }
 
         } // end namespace import

--- a/include/pstore/mcrepo/compilation.hpp
+++ b/include/pstore/mcrepo/compilation.hpp
@@ -238,12 +238,12 @@ namespace pstore {
                 {'C', 'm', 'p', 'l', '8', 'i', 'o', 'n'}};
 
             std::array<char, 8> signature_ = compilation_signature_;
+            /// The target triple for this compilation.
+            typed_address<indirect_string> triple_;
             /// The number of entries in the members_ array.
             size_type size_ = 0;
             std::uint32_t padding1_ = 0;
 
-            /// The target triple for this compilation.
-            typed_address<indirect_string> triple_;
             definition members_[1];
         };
         PSTORE_STATIC_ASSERT (std::is_standard_layout<compilation>::value);
@@ -253,14 +253,14 @@ namespace pstore {
         template <typename Iterator>
         compilation::compilation (typed_address<indirect_string> const triple, size_type const size,
                                   Iterator const first_member, Iterator const last_member) noexcept
-                : size_{size}
-                , triple_{triple} {
-            // Assignments to suppress warnings from clang that the fields are not used.
+                : triple_{triple}
+                , size_{size} {
+            // Assignment to suppress a warning from clang that the field is not used.
             padding1_ = 0;
             PSTORE_STATIC_ASSERT (offsetof (compilation, signature_) == 0);
-            PSTORE_STATIC_ASSERT (offsetof (compilation, size_) == 8);
-            PSTORE_STATIC_ASSERT (offsetof (compilation, padding1_) == 12);
-            PSTORE_STATIC_ASSERT (offsetof (compilation, triple_) == 16);
+            PSTORE_STATIC_ASSERT (offsetof (compilation, triple_) == 8);
+            PSTORE_STATIC_ASSERT (offsetof (compilation, size_) == 16);
+            PSTORE_STATIC_ASSERT (offsetof (compilation, padding1_) == 20);
             PSTORE_STATIC_ASSERT (offsetof (compilation, members_) == 32);
 
             // This check can safely be an assertion because the method is private and alloc(),

--- a/include/pstore/mcrepo/compilation.hpp
+++ b/include/pstore/mcrepo/compilation.hpp
@@ -137,7 +137,6 @@ namespace pstore {
             /// of a vector of definitions into it.
             ///
             /// \param transaction  The transaction to which the compilation will be appended.
-            /// \param path  A ticket file path address in the store.
             /// \param triple  The target-triple associated with this compilation.
             /// \param first_member  The first of a sequence of definition instances. The
             ///   range defined by \p first_member and \p last_member will be copied into the newly
@@ -147,7 +146,6 @@ namespace pstore {
             ///   the in-store location of the allocated compilation.
             template <typename TransactionType, typename Iterator>
             static extent<compilation> alloc (TransactionType & transaction,
-                                              typed_address<indirect_string> path,
                                               typed_address<indirect_string> triple,
                                               Iterator first_member, Iterator last_member);
 
@@ -205,8 +203,6 @@ namespace pstore {
             }
             ///@}
 
-            /// Returns the ticket file path.
-            typed_address<indirect_string> path () const noexcept { return path_; }
             /// Returns the target triple.
             typed_address<indirect_string> triple () const noexcept { return triple_; }
 
@@ -224,8 +220,8 @@ namespace pstore {
 
         private:
             template <typename Iterator>
-            compilation (typed_address<indirect_string> path, typed_address<indirect_string> triple,
-                         size_type size, Iterator first_member, Iterator last_member) noexcept;
+            compilation (typed_address<indirect_string> triple, size_type size,
+                         Iterator first_member, Iterator last_member) noexcept;
 
             struct nmembers {
                 size_type n;
@@ -242,15 +238,12 @@ namespace pstore {
                 {'C', 'm', 'p', 'l', '8', 'i', 'o', 'n'}};
 
             std::array<char, 8> signature_ = compilation_signature_;
-
-            /// The path containing the ticket file when it was created. (Used to guide the garbage
-            /// collector's ticket-file search.)
-            typed_address<indirect_string> path_;
-            /// The target triple for this compilation.
-            typed_address<indirect_string> triple_;
             /// The number of entries in the members_ array.
             size_type size_ = 0;
             std::uint32_t padding1_ = 0;
+
+            /// The target triple for this compilation.
+            typed_address<indirect_string> triple_;
             definition members_[1];
         };
         PSTORE_STATIC_ASSERT (std::is_standard_layout<compilation>::value);
@@ -258,19 +251,16 @@ namespace pstore {
         PSTORE_STATIC_ASSERT (alignof (compilation) == 16);
 
         template <typename Iterator>
-        compilation::compilation (typed_address<indirect_string> const path,
-                                  typed_address<indirect_string> const triple, size_type const size,
+        compilation::compilation (typed_address<indirect_string> const triple, size_type const size,
                                   Iterator const first_member, Iterator const last_member) noexcept
-                : path_{path}
-                , triple_{triple}
-                , size_{size} {
-            // An assignment to suppress a warning from clang that the field is not used.
+                : size_{size}
+                , triple_{triple} {
+            // Assignments to suppress warnings from clang that the fields are not used.
             padding1_ = 0;
             PSTORE_STATIC_ASSERT (offsetof (compilation, signature_) == 0);
-            PSTORE_STATIC_ASSERT (offsetof (compilation, path_) == 8);
+            PSTORE_STATIC_ASSERT (offsetof (compilation, size_) == 8);
+            PSTORE_STATIC_ASSERT (offsetof (compilation, padding1_) == 12);
             PSTORE_STATIC_ASSERT (offsetof (compilation, triple_) == 16);
-            PSTORE_STATIC_ASSERT (offsetof (compilation, size_) == 24);
-            PSTORE_STATIC_ASSERT (offsetof (compilation, padding1_) == 28);
             PSTORE_STATIC_ASSERT (offsetof (compilation, members_) == 32);
 
             // This check can safely be an assertion because the method is private and alloc(),
@@ -283,7 +273,7 @@ namespace pstore {
         // alloc
         // ~~~~~
         template <typename TransactionType, typename Iterator>
-        auto compilation::alloc (TransactionType & transaction, typed_address<indirect_string> path,
+        auto compilation::alloc (TransactionType & transaction,
                                  typed_address<indirect_string> triple, Iterator first_member,
                                  Iterator last_member) -> extent<compilation> {
             // First work out its size.
@@ -302,7 +292,7 @@ namespace pstore {
             auto ptr = std::static_pointer_cast<compilation> (transaction.getrw (addr, size));
 
             // Write the data to the store.
-            new (ptr.get ()) compilation{path, triple, num_members, first_member, last_member};
+            new (ptr.get ()) compilation{triple, num_members, first_member, last_member};
             return extent<compilation> (typed_address<compilation> (addr), size);
         }
 

--- a/lib/core/database.cpp
+++ b/lib/core/database.cpp
@@ -292,9 +292,10 @@ namespace pstore {
 
         using present_mode = file::file_handle::present_mode;
         auto const create_mode = file::file_handle::create_mode::open_existing;
-        auto const write_mode = (am == access_mode::writable)
-                                    ? file::file_handle::writable_mode::read_write
-                                    : file::file_handle::writable_mode::read_only;
+        auto const write_mode =
+            (am == access_mode::writable || am == access_mode::writeable_no_create)
+                ? file::file_handle::writable_mode::read_write
+                : file::file_handle::writable_mode::read_only;
 
         auto file = std::make_shared<file::file_handle> (path);
         file->open (create_mode, write_mode, present_mode::allow_not_found);

--- a/lib/dump/mcrepo_value.cpp
+++ b/lib/dump/mcrepo_value.cpp
@@ -224,7 +224,6 @@ namespace pstore {
             using archive::make_reader;
             return make_value (object::container{
                 {"members", make_value (members)},
-                {"path", make_value (indirect_string::read (parm.db, compilation->path ()))},
                 {"triple", make_value (indirect_string::read (parm.db, compilation->triple ()))},
             });
         }

--- a/lib/exchange/CMakeLists.txt
+++ b/lib/exchange/CMakeLists.txt
@@ -25,6 +25,7 @@ set (pstore_exchange_includes
     export_fragment.hpp
     export_ostream.hpp
     export_names.hpp
+    export_paths.hpp
     export_section.hpp
     import_bss_section.hpp
     import_compilation.hpp
@@ -53,6 +54,7 @@ set (pstore_exchange_sources
     export_fixups.cpp
     export_fragment.cpp
     export_names.cpp
+    export_paths.cpp
     export_ostream.cpp
     import_compilation.cpp
     import_debug_line_header.cpp

--- a/lib/exchange/export.cpp
+++ b/lib/exchange/export.cpp
@@ -78,7 +78,9 @@ namespace pstore {
         namespace export_ns {
 
             void emit_database (database & db, ostream & os, bool const comments) {
-                name_mapping string_table{db};
+                name_mapping string_table{db, name_index_tag ()};
+                name_mapping path_table{db, path_index_tag ()};
+
                 auto const ind = indent{}.next ();
                 os << "{\n";
                 os << ind << R"("version":1,)" << '\n';
@@ -87,33 +89,37 @@ namespace pstore {
 
                 auto const f = footers (db);
                 PSTORE_ASSERT (std::distance (std::begin (f), std::end (f)) >= 1);
-                emit_array (os, ind, std::next (std::begin (f)), std::end (f),
-                            [&] (ostream & os1, indent const ind1,
-                                 pstore::typed_address<pstore::trailer> const footer_pos) {
-                                auto const footer = db.getro (footer_pos);
-                                unsigned const generation = footer->a.generation;
-                                db.sync (generation);
-                                os1 << ind1 << "{\n";
-                                auto const object_indent = ind1.next ();
-                                if (comments) {
-                                    os1 << object_indent << "// generation " << generation << '\n';
-                                }
-                                os1 << object_indent << R"("names":)";
-                                emit_names (os1, object_indent, db, generation, &string_table);
-                                os1 << ",\n" << object_indent << R"("debugline":{)";
-                                emit_debug_line_headers (os1, object_indent.next (), db,
-                                                         generation);
-                                os1 << '\n' << object_indent << "},\n";
-                                os1 << object_indent << R"("fragments":{)";
-                                emit_fragments (os1, object_indent.next (), db, generation,
+                emit_array (
+                    os, ind, std::next (std::begin (f)), std::end (f),
+                    [&] (ostream & os1, indent const ind1,
+                         pstore::typed_address<pstore::trailer> const footer_pos) {
+                        auto const footer = db.getro (footer_pos);
+                        unsigned const generation = footer->a.generation;
+                        db.sync (generation);
+                        os1 << ind1 << "{\n";
+                        auto const object_indent = ind1.next ();
+                        if (comments) {
+                            os1 << object_indent << "// transaction #" << generation << '\n';
+                        }
+                        os1 << object_indent << R"("names":)";
+                        emit_strings<trailer::indices::name> (os1, object_indent, db, generation,
+                                                              &string_table);
+                        os1 << ",\n" << object_indent << R"("paths":)";
+                        emit_strings<trailer::indices::path> (os1, object_indent, db, generation,
+                                                              &path_table);
+                        os1 << ",\n" << object_indent << R"("debugline":{)";
+                        emit_debug_line_headers (os1, object_indent.next (), db, generation);
+                        os1 << '\n' << object_indent << "},\n";
+                        os1 << object_indent << R"("fragments":{)";
+                        emit_fragments (os1, object_indent.next (), db, generation, string_table,
+                                        comments);
+                        os1 << '\n' << object_indent << "},\n";
+                        os1 << object_indent << R"("compilations":{)";
+                        emit_compilation_index (os1, object_indent.next (), db, generation,
                                                 string_table, comments);
-                                os1 << '\n' << object_indent << "},\n";
-                                os1 << object_indent << R"("compilations":{)";
-                                emit_compilation_index (os1, object_indent.next (), db, generation,
-                                                        string_table, comments);
-                                os1 << '\n' << object_indent << "}\n";
-                                os1 << ind1 << '}';
-                            });
+                        os1 << '\n' << object_indent << "}\n";
+                        os1 << ind1 << '}';
+                    });
                 os << "\n}\n";
             }
 

--- a/lib/exchange/export_compilation.cpp
+++ b/lib/exchange/export_compilation.cpp
@@ -61,10 +61,7 @@ namespace pstore {
                                    name_mapping const & names, bool const comments) {
                 os << "{\n";
                 auto const object_indent = ind.next ();
-                os << object_indent << R"("path":)" << names.index (compilation.path ()) << ',';
-                show_string (os, db, compilation.path (), comments);
-                os << '\n'
-                   << object_indent << R"("triple":)" << names.index (compilation.triple ()) << ',';
+                os << object_indent << R"("triple":)" << names.index (compilation.triple ()) << ',';
                 show_string (os, db, compilation.triple (), comments);
                 os << '\n' << object_indent << R"("definitions":)";
                 emit_array_with_name (os, object_indent, db, compilation.begin (),

--- a/lib/exchange/export_emit.cpp
+++ b/lib/exchange/export_emit.cpp
@@ -41,13 +41,11 @@ namespace pstore {
                 emit_string (os, std::begin (view), std::end (view));
             }
 
-            ostream_base & show_string (ostream_base & os, pstore::database const & db,
-                                        pstore::typed_address<pstore::indirect_string> const addr,
+            ostream_base & show_string (ostream_base & os, database const & db,
+                                        typed_address<pstore::indirect_string> const addr,
                                         bool const comments) {
                 if (comments) {
-                    auto const str = serialize::read<pstore::indirect_string> (
-                        serialize::archive::database_reader{db, addr.to_address ()});
-                    os << R"( //")" << str << '"';
+                    os << R"( //")" << indirect_string::read (db, addr) << '"';
                 }
                 return os;
             }

--- a/lib/exchange/export_names.cpp
+++ b/lib/exchange/export_names.cpp
@@ -29,13 +29,6 @@ namespace pstore {
             //* | ' \/ _` | '  \/ -_) | '  \/ _` | '_ \ '_ \ | ' \/ _` | *
             //* |_||_\__,_|_|_|_\___| |_|_|_\__,_| .__/ .__/_|_||_\__, | *
             //*                                  |_|  |_|         |___/  *
-            // (ctor)
-            // ~~~~~~
-            name_mapping::name_mapping (database const & db) {
-                auto const index = index::get_index<trailer::indices::name> (db);
-                names_.reserve (index->size ());
-            }
-
             // add
             // ~~~
             void name_mapping::add (address const addr) {
@@ -52,40 +45,6 @@ namespace pstore {
                 PSTORE_ASSERT (pos != names_.end ());
                 return pos->second;
             }
-
-            //*            _ _                             *
-            //*  ___ _ __ (_) |_   _ _  __ _ _ __  ___ ___ *
-            //* / -_) '  \| |  _| | ' \/ _` | '  \/ -_|_-< *
-            //* \___|_|_|_|_|\__| |_||_\__,_|_|_|_\___/__/ *
-            //*                                            *
-            void emit_names (ostream_base & os, indent const ind, database const & db,
-                             unsigned const generation, name_mapping * const string_table) {
-                auto const names_index = index::get_index<trailer::indices::name> (db);
-                PSTORE_ASSERT (generation > 0);
-
-                auto const * separator = "";
-                auto const * tail_separator = "";
-                auto close_bracket_indent = indent{};
-
-                auto const member_indent = ind.next ();
-                auto const out_fn = [&] (pstore::address const addr) {
-                    os << separator << '\n' << member_indent;
-                    {
-                        indirect_string const str = names_index->load_leaf_node (db, addr);
-                        shared_sstring_view owner;
-                        raw_sstring_view const view = str.as_db_string_view (&owner);
-                        emit_string (os, view);
-                        string_table->add (addr);
-                    }
-                    separator = ",";
-                    tail_separator = "\n";
-                    close_bracket_indent = ind;
-                };
-                os << '[';
-                diff (db, *names_index, generation - 1U, make_diff_out (&out_fn));
-                os << tail_separator << close_bracket_indent << ']';
-            }
-
 
         } // end namespace export_ns
     }     // end namespace exchange

--- a/lib/exchange/export_paths.cpp
+++ b/lib/exchange/export_paths.cpp
@@ -1,3 +1,18 @@
+//===- lib/exchange/export_paths.cpp --------------------------------------===//
+//*                             _                 _   _          *
+//*   _____  ___ __   ___  _ __| |_   _ __   __ _| |_| |__  ___  *
+//*  / _ \ \/ / '_ \ / _ \| '__| __| | '_ \ / _` | __| '_ \/ __| *
+//* |  __/>  <| |_) | (_) | |  | |_  | |_) | (_| | |_| | | \__ \ *
+//*  \___/_/\_\ .__/ \___/|_|   \__| | .__/ \__,_|\__|_| |_|___/ *
+//*           |_|                    |_|                         *
+//===----------------------------------------------------------------------===//
+//
+// Part of the pstore project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://github.com/SNSystems/pstore/blob/master/LICENSE.txt for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
 #include "pstore/exchange/export_paths.hpp"
 
 #include <cassert>

--- a/lib/exchange/export_paths.cpp
+++ b/lib/exchange/export_paths.cpp
@@ -13,6 +13,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+/// \file export_paths.cpp
+/// \brief  Exporting the members of the paths index.
+
 #include "pstore/exchange/export_paths.hpp"
 
 #include <cassert>
@@ -20,8 +23,6 @@
 
 #include "pstore/core/diff.hpp"
 #include "pstore/core/index_types.hpp"
-//#include "pstore/exchange/export_emit.hpp"
-//#include "pstore/exchange/export_names.hpp"
 #include "pstore/exchange/export_ostream.hpp"
 
 namespace pstore {

--- a/lib/exchange/export_paths.cpp
+++ b/lib/exchange/export_paths.cpp
@@ -1,0 +1,43 @@
+#include "pstore/exchange/export_paths.hpp"
+
+#include <cassert>
+#include <limits>
+
+#include "pstore/core/diff.hpp"
+#include "pstore/core/index_types.hpp"
+//#include "pstore/exchange/export_emit.hpp"
+//#include "pstore/exchange/export_names.hpp"
+#include "pstore/exchange/export_ostream.hpp"
+
+namespace pstore {
+    namespace exchange {
+        namespace export_ns {
+
+            void emit_paths (ostream_base & os, indent const ind, database const & db,
+                             unsigned const generation,
+                             gsl::not_null<name_mapping *> const string_table) {
+                auto const paths_index = index::get_index<trailer::indices::path> (db);
+                PSTORE_ASSERT (generation > 0);
+
+                auto const * separator = "";
+                auto const * tail_separator = "";
+                auto close_bracket_indent = indent{};
+
+                auto const member_indent = ind.next ();
+                auto const out_fn = [&] (pstore::address const addr) {
+                    os << separator << '\n'
+                       << member_indent
+                       << string_table->index (typed_address<indirect_string>::make (addr));
+
+                    separator = ",";
+                    tail_separator = "\n";
+                    close_bracket_indent = ind;
+                };
+                os << '[';
+                diff (db, *paths_index, generation - 1U, make_diff_out (&out_fn));
+                os << tail_separator << close_bracket_indent << ']';
+            }
+
+        } // end namespace export_ns
+    }     // end namespace exchange
+} // end namespace pstore

--- a/lib/exchange/import_compilation.cpp
+++ b/lib/exchange/import_compilation.cpp
@@ -185,10 +185,6 @@ namespace pstore {
             // key
             // ~~~
             std::error_code compilation::key (std::string const & k) {
-                if (k == "path") {
-                    seen_[path_index] = true;
-                    return push<uint64_rule> (&path_);
-                }
                 if (k == "triple") {
                     seen_[triple_index] = true;
                     return push<uint64_rule> (&triple_);
@@ -206,19 +202,14 @@ namespace pstore {
                 if (!seen_.all ()) {
                     return error::incomplete_compilation_object;
                 }
-                auto const path = names_->lookup (path_);
-                if (!path) {
-                    return path.get_error ();
-                }
                 auto const triple = names_->lookup (triple_);
                 if (!triple) {
                     return triple.get_error ();
                 }
 
                 // Create the compilation record in the store.
-                extent<repo::compilation> const compilation_extent =
-                    repo::compilation::alloc (*transaction_, *path, *triple,
-                                              std::begin (definitions_), std::end (definitions_));
+                extent<repo::compilation> const compilation_extent = repo::compilation::alloc (
+                    *transaction_, *triple, std::begin (definitions_), std::end (definitions_));
 
                 // Insert this compilation into the compilations index.
                 auto const compilations =

--- a/lib/exchange/import_compilation.cpp
+++ b/lib/exchange/import_compilation.cpp
@@ -175,7 +175,7 @@ namespace pstore {
                                       not_null<transaction_base *> const transaction,
                                       not_null<name_mapping const *> const names,
                                       fragment_index_pointer const & fragments,
-                                      index::digest const digest)
+                                      index::digest const & digest)
                     : rule (ctxt)
                     , transaction_{transaction}
                     , names_{names}
@@ -190,6 +190,7 @@ namespace pstore {
                     return push<uint64_rule> (&triple_);
                 }
                 if (k == "definitions") {
+                    seen_[definitions_index] = true;
                     return push_array_rule<definition_object> (this, &definitions_, names_,
                                                                fragments_);
                 }

--- a/lib/exchange/import_root.cpp
+++ b/lib/exchange/import_root.cpp
@@ -46,6 +46,7 @@ namespace {
 
     private:
         pstore::exchange::import::name_mapping names_;
+        pstore::exchange::import::name_mapping paths_;
 
         enum { version, id, transactions };
         std::bitset<transactions + 1> seen_;
@@ -73,7 +74,7 @@ namespace {
         }
         if (k == "transactions") {
             seen_[transactions] = true;
-            return push<transaction_array<pstore::transaction_lock>> (&names_);
+            return push<transaction_array<pstore::transaction_lock>> (&names_, &paths_);
         }
         return error::unrecognized_root_key;
     }

--- a/system_tests/exchange/test.json
+++ b/system_tests/exchange/test.json
@@ -3,9 +3,8 @@
   "id":"2dedee5a-6992-49d5-b98b-9f6fa95418f3",
   "transactions":[
     {
-      // generation 1
+      // transaction #1
       "names":[
-        "/Users/paul/test/two_modules",
         "x86_64-pc-linux-gnu-repo",
         "puts",
         "main",
@@ -16,6 +15,9 @@
         "ultimate_answer",
         "foo"
       ],
+      "paths": [
+        "/Users/paul/test"
+      ],
       "debugline":{
       },
       "fragments":{
@@ -25,31 +27,31 @@
             "data":"UL8AAAAA6AAAAAC/BgAAAOgAAAAAvwAAAACJxjHA6AAAAAAxwFnD",
             "xfixups":[
               {
-                "name":5, //"str.3832e937033435e0077a688e7b9ec336"
+                "name":4, //"str.3832e937033435e0077a688e7b9ec336"
                 "type":10,
                 "offset":2,
                 "addend":0
               },
               {
-                "name":2, //"puts"
+                "name":1, //"puts"
                 "type":4,
                 "offset":7,
                 "addend":-4
               },
               {
-                "name":9, //"foo"
+                "name":8, //"foo"
                 "type":4,
                 "offset":17,
                 "addend":-4
               },
               {
-                "name":6, //".str.1"
+                "name":5, //".str.1"
                 "type":10,
                 "offset":22,
                 "addend":0
               },
               {
-                "name":4, //"printf"
+                "name":3, //"printf"
                 "type":4,
                 "offset":31,
                 "addend":-4
@@ -79,27 +81,26 @@
       },
       "compilations":{
         "ec261f9049865026bc721a944a51728d":{
-          "path":0, //"/Users/paul/test/two_modules"
-          "triple":1, //"x86_64-pc-linux-gnu-repo"
+          "triple":0, //"x86_64-pc-linux-gnu-repo"
           "definitions":[
             {
               "digest":"c013773d4b1b506fab3b926d57223e5d",
-              "name":8, //"ultimate_answer"
+              "name":7, //"ultimate_answer"
               "linkage":"external"
             },
             {
               "digest":"6754f6ae81754f024540e2278491a4eb",
-              "name":3, //"main"
+              "name":2, //"main"
               "linkage":"external"
             },
             {
               "digest":"8994913c7f70bae8ce714e979176185a",
-              "name":6, //".str.1"
+              "name":5, //".str.1"
               "linkage":"internal_no_symbol"
             },
             {
               "digest":"36c39e7b8e687a07e035340337e93238",
-              "name":5, //"str.3832e937033435e0077a688e7b9ec336"
+              "name":4, //"str.3832e937033435e0077a688e7b9ec336"
               "linkage":"internal_no_symbol"
             }
           ]
@@ -107,10 +108,7 @@
       }
     },
     {
-      // generation 2
-      "names":[],
-      "debugline":{
-      },
+      // transaction #2
       "fragments":{
         "e9ad970e83dcf9a95a6c822947278609":{
           "text":{
@@ -121,12 +119,11 @@
       },
       "compilations":{
         "adb6caf1c6292f18934d1ec2c31d813b":{
-          "path":0, //"/Users/paul/test/two_modules"
-          "triple":1, //"x86_64-pc-linux-gnu-repo"
+          "triple":0, //"x86_64-pc-linux-gnu-repo"
           "definitions":[
             {
               "digest":"e9ad970e83dcf9a95a6c822947278609",
-              "name":9, //"foo"
+              "name":8, //"foo"
               "linkage":"external"
             }
           ]

--- a/tools/dump/switches.cpp
+++ b/tools/dump/switches.cpp
@@ -85,13 +85,22 @@ namespace {
     opt<bool> indices{"indices", desc{"Dump the indices"}, cat (what_cat)};
     alias indices2{"i", desc{"Alias for --indices"}, aliasopt{indices}};
 
-    opt<bool> log_opt{"log", desc{"List the generations"}, cat (what_cat)};
+    opt<bool> log_opt{"log", desc{"List the transactions"}, cat (what_cat)};
     alias log2{"l", desc{"Alias for --log"}, aliasopt{log_opt}};
 
-    opt<bool> all{"all",
-                  desc{"Show store-related output. Equivalent to: --all-compilations "
-                       "--all-debug-line-headers --all-fragments --header --indices --log"},
-                  cat (what_cat)};
+
+    opt<bool> names_opt{"names", desc{"Dump the name index"}, cat (what_cat)};
+    alias names2{"n", desc{"Alias for --names"}, aliasopt{names_opt}};
+    opt<bool> paths_opt{"paths", desc{"Dump the path index"}, cat (what_cat)};
+    alias paths2{"p", desc{"Alias for --paths"}, aliasopt{paths_opt}};
+
+
+
+    opt<bool> all{
+        "all",
+        desc{"Show store-related output. Equivalent to: --all-compilations "
+             "--all-debug-line-headers --all-fragments --header --indices --log --names --paths"},
+        cat (what_cat)};
     alias all2{"a", desc{"Alias for --all"}, aliasopt{all}};
 
     opt<bool> shared_memory{"shared-memory", desc{"Dumps the shared-memory block"}, cat (what_cat)};
@@ -146,7 +155,16 @@ std::pair<switches, int> get_switches (int argc, tchar * argv[]) {
     result.show_indices = indices.get ();
     result.show_log = log_opt.get ();
     result.show_shared = shared_memory.get ();
-    result.show_all = all.get ();
+
+    result.show_names = names_opt.get ();
+    result.show_paths = paths_opt.get ();
+
+    if (all) {
+        result.show_all_compilations = result.show_all_debug_line_headers =
+            result.show_all_fragments = result.show_header = result.show_indices = result.show_log =
+                result.show_names = result.show_paths = true;
+    }
+
     result.revision = static_cast<unsigned> (revision.get ());
 
     result.hex = hex.get ();

--- a/tools/dump/switches.hpp
+++ b/tools/dump/switches.hpp
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+/// \file switches.hpp
+/// \brief Defines a structure which represents the dump tool's command-line switches.
 #ifndef PSTORE_DUMP_SWITCHES_HPP
 #define PSTORE_DUMP_SWITCHES_HPP
 
@@ -47,6 +49,11 @@ struct switches {
     bool show_indices = false;
     bool show_log = false;
     bool show_shared = false;
+
+    /// True if --names was specified.
+    bool show_names = false;
+    /// True if --paths was specified.
+    bool show_paths = false;
 
     unsigned revision = pstore::head_revision;
 

--- a/unittests/dump/test_db.cpp
+++ b/unittests/dump/test_db.cpp
@@ -151,8 +151,9 @@ TEST (Database, Trailer) {
                  ElementsAre ("time", ":", "1970-01-01T00:00:00Z"));
 
     EXPECT_THAT (split_tokens (lines.at (line++)), ElementsAre ("prev_generation", ":", "0x0"));
-    EXPECT_THAT (split_tokens (lines.at (line++)),
-                 ElementsAre ("indices", ":", "[", "0x0,", "0x0,", "0x0,", "0x0,", "0x0", "]"));
+    EXPECT_THAT (
+        split_tokens (lines.at (line++)),
+        ElementsAre ("indices", ":", "[", "0x0,", "0x0,", "0x0,", "0x0,", "0x0,", "0x0", "]"));
 
     EXPECT_THAT (split_tokens (lines.at (line++)), ElementsAre ("crc", ":", _));
     EXPECT_THAT (split_tokens (lines.at (line++)),

--- a/unittests/dump/test_mcrepo.cpp
+++ b/unittests/dump/test_mcrepo.cpp
@@ -252,8 +252,7 @@ TEST_F (MCRepoFixture, DumpCompilation) {
                                this->store_str (transaction, "main"), linkage::external,
                                visibility::hidden_vis}};
     auto compilation = compilation::load (
-        *db_, compilation::alloc (transaction, this->store_str (transaction, "/home/user/"),
-                                  this->store_str (transaction, "machine-vendor-os"),
+        *db_, compilation::alloc (transaction, this->store_str (transaction, "machine-vendor-os"),
                                   std::begin (v), std::end (v)));
 
     std::ostringstream out;
@@ -266,7 +265,7 @@ TEST_F (MCRepoFixture, DumpCompilation) {
     addr->write (out);
 
     auto const lines = split_lines (out.str ());
-    ASSERT_EQ (8U, lines.size ());
+    ASSERT_EQ (7U, lines.size ());
 
     auto line = 0U;
     EXPECT_THAT (split_tokens (lines.at (line++)), ElementsAre ("members", ":"));
@@ -277,7 +276,6 @@ TEST_F (MCRepoFixture, DumpCompilation) {
     EXPECT_THAT (split_tokens (lines.at (line++)), ElementsAre ("name", ":", "main"));
     EXPECT_THAT (split_tokens (lines.at (line++)), ElementsAre ("linkage", ":", "external"));
     EXPECT_THAT (split_tokens (lines.at (line++)), ElementsAre ("visibility", ":", "hidden"));
-    EXPECT_THAT (split_tokens (lines.at (line++)), ElementsAre ("path", ":", "/home/user/"));
     EXPECT_THAT (split_tokens (lines.at (line++)),
                  ElementsAre ("triple", ":", "machine-vendor-os"));
 }

--- a/unittests/exchange/CMakeLists.txt
+++ b/unittests/exchange/CMakeLists.txt
@@ -24,6 +24,7 @@ add_pstore_unit_test (pstore-exchange-unit-tests
     test_export_ostream.cpp
     test_generic_section.cpp
     test_linked_definitions_section.cpp
+    test_paths.cpp
     test_section_fixups.cpp
     test_terminal.cpp
     test_uuid.cpp

--- a/unittests/exchange/add_export_strings.hpp
+++ b/unittests/exchange/add_export_strings.hpp
@@ -40,19 +40,22 @@
 ///
 ///     std::vector<pstore::gsl::czstring> strings{"foo", "bar"};
 ///     std::unordered_map<std::string, string_address> indir_strings;
-///     add_export_strings (export_db_, std::begin (strings), std::end (strings),
-///                         std::inserter (indir_strings, std::end (indir_strings)));
+///     using index = pstore::trailer::indices::name;
+///     add_export_strings<index> (export_db_,
+///                                std::begin (strings), std::end (strings),
+///                                std::inserter (indir_strings, std::end (indir_strings)));
 ///
+/// \tparam Index  Tge index in which the strings are held.
 /// \param db  The database in which the strings will be written.
 /// \param first  The first of the range of strings to be stored.
 /// \param last  The end of the range of strings to be stored.
 /// \param out  An OutputIterator which will store a pair<czstring, string_address>
-template <typename InputIterator, typename OutputIterator>
+template <pstore::trailer::indices Index, typename InputIterator, typename OutputIterator>
 void add_export_strings (pstore::database & db, InputIterator first, InputIterator last,
                          OutputIterator out) {
     mock_mutex mutex;
     auto transaction = begin (db, std::unique_lock<mock_mutex>{mutex});
-    auto const name_index = pstore::index::get_index<pstore::trailer::indices::name> (db);
+    auto const name_index = pstore::index::get_index<Index> (db);
 
     std::vector<pstore::raw_sstring_view> views;
     std::transform (first, last, std::back_inserter (views),

--- a/unittests/exchange/compare_external_fixups.hpp
+++ b/unittests/exchange/compare_external_fixups.hpp
@@ -37,9 +37,7 @@ void compare_external_fixups (pstore::database const & export_db,
 
     auto const load_string = [] (pstore::database const & db, string_address const addr,
                                  pstore::gsl::not_null<pstore::shared_sstring_view *> const owner) {
-        using namespace pstore::serialize;
-        return read<pstore::indirect_string> (archive::database_reader{db, addr.to_address ()})
-            .as_string_view (owner);
+        return pstore::indirect_string::read (db, addr).as_string_view (owner);
     };
 
     // The name fields are tricky here. The imported and exported fixups are from different

--- a/unittests/exchange/test_bss_section.cpp
+++ b/unittests/exchange/test_bss_section.cpp
@@ -69,7 +69,8 @@ TEST_F (BssSection, RoundTripForAnEmptySection) {
     static_assert (std::is_same<section_type, pstore::repo::bss_section>::value,
                    "Expected bss to map to bss_section");
 
-    pstore::exchange::export_ns::name_mapping exported_names{export_db_};
+    pstore::exchange::export_ns::name_mapping exported_names{
+        export_db_, pstore::exchange::export_ns::name_index_tag ()};
     pstore::repo::section_content exported_content{kind};
     std::string const exported_json =
         export_section<kind> (export_db_, exported_names, exported_content, false);
@@ -107,7 +108,8 @@ TEST_F (BssSection, RoundTripForPopulated) {
     static_assert (std::is_same<section_type, pstore::repo::bss_section>::value,
                    "Expected bss to map to bss_section");
 
-    pstore::exchange::export_ns::name_mapping exported_names{export_db_};
+    pstore::exchange::export_ns::name_mapping exported_names{
+        export_db_, pstore::exchange::export_ns::name_index_tag ()};
 
     pstore::repo::section_content exported_content{kind};
     exported_content.align = 32U;

--- a/unittests/exchange/test_linked_definitions_section.cpp
+++ b/unittests/exchange/test_linked_definitions_section.cpp
@@ -80,7 +80,8 @@ namespace {
 
         transaction.commit ();
 
-        exchange::export_ns::name_mapping exported_names{export_db_};
+        exchange::export_ns::name_mapping exported_names{
+            export_db_, pstore::exchange::export_ns::name_index_tag ()};
         exchange::export_ns::ostringstream str;
         emit_fragment (str, exchange::export_ns::indent{}, export_db_, exported_names,
                        export_db_.getro (fext), true);
@@ -150,11 +151,10 @@ TEST_F (LinkedDefinitionsSection, RoundTripForPopulated) {
             auto compilation_index =
                 pstore::index::get_index<pstore::trailer::indices::compilation> (transaction.db ());
             compilation_index->insert (
-                transaction,
-                std::make_pair (referenced_compilation_digest,
-                                repo::compilation::alloc (transaction, str /*path*/, str /*triple*/,
-                                                          std::begin (definitions),
-                                                          std::end (definitions))));
+                transaction, std::make_pair (referenced_compilation_digest,
+                                             repo::compilation::alloc (transaction, str /*triple*/,
+                                                                       std::begin (definitions),
+                                                                       std::end (definitions))));
         }
         transaction.commit ();
     }

--- a/unittests/exchange/test_paths.cpp
+++ b/unittests/exchange/test_paths.cpp
@@ -1,0 +1,160 @@
+#include "pstore/exchange/export_names.hpp"
+#include "pstore/exchange/import_names.hpp"
+
+// Standard library includes
+#include <array>
+#include <string>
+#include <unordered_map>
+
+// 3rd party includes
+#include <gtest/gtest.h>
+
+// pstore includes
+#include "pstore/core/database.hpp"
+#include "pstore/core/indirect_string.hpp"
+#include "pstore/exchange/export_names.hpp"
+#include "pstore/exchange/import_names_array.hpp"
+#include "pstore/support/gsl.hpp"
+#include "pstore/json/json.hpp"
+#include "pstore/exchange/import_non_terminals.hpp"
+
+// local includes
+#include "add_export_strings.hpp"
+#include "empty_store.hpp"
+
+using namespace std::string_literals;
+
+namespace {
+
+    using transaction_lock = std::unique_lock<mock_mutex>;
+    using transaction = pstore::transaction<transaction_lock>;
+
+    class ExchangePaths : public testing::Test {
+    public:
+        ExchangePaths ()
+                : export_db_{export_store_.file ()}
+                , import_db_{import_store_.file ()} {
+            export_db_.set_vacuum_mode (pstore::database::vacuum_mode::disabled);
+            import_db_.set_vacuum_mode (pstore::database::vacuum_mode::disabled);
+        }
+
+        InMemoryStore export_store_;
+        pstore::database export_db_;
+
+        InMemoryStore import_store_;
+        pstore::database import_db_;
+    };
+
+    template <typename ImportRule, typename... Args>
+    pstore::json::parser<pstore::exchange::import::callbacks>
+    make_json_array_parser (pstore::database * const db, Args... args) {
+        using namespace pstore::exchange::import;
+        return pstore::json::make_parser (
+            callbacks::make<array_rule<ImportRule, Args...>> (db, args...));
+    }
+
+    // Parse the exported names JSON. The resulting index-to-string mappings are then available via
+    // imported_names.
+    decltype (auto) import_name_parser (transaction * const transaction,
+                                        pstore::exchange::import::name_mapping * const names) {
+        return make_json_array_parser<pstore::exchange::import::names_array_members> (
+            &transaction->db (), transaction, names);
+    }
+
+} // end anonymous namespace
+
+TEST_F (ExchangePaths, ExportEmpty) {
+    using namespace pstore::exchange::export_ns;
+
+    name_mapping exported_names{export_db_, path_index_tag ()};
+    ostringstream exported_names_stream;
+    emit_strings<pstore::trailer::indices::path> (exported_names_stream, indent{}, export_db_,
+                                                  export_db_.get_current_revision (),
+                                                  &exported_names);
+
+    EXPECT_EQ (exported_names_stream.str (), "[]");
+    EXPECT_EQ (exported_names.size (), 0U);
+}
+
+TEST_F (ExchangePaths, ImportEmpty) {
+    auto const exported_paths = "[]\n"s;
+
+    mock_mutex mutex;
+    auto transaction = begin (import_db_, transaction_lock{mutex});
+
+    pstore::exchange::import::name_mapping imported_paths;
+    {
+        auto name_parser = import_name_parser (&transaction, &imported_paths);
+        name_parser.input (exported_paths).eof ();
+        ASSERT_FALSE (name_parser.has_error ())
+            << "JSON error was: " << name_parser.last_error ().message () << ' '
+            << name_parser.coordinate () << '\n'
+            << exported_paths;
+    }
+
+    imported_paths.flush (&transaction);
+    transaction.commit ();
+
+    EXPECT_EQ (imported_paths.lookup (0U), pstore::exchange::import::error::no_such_name);
+}
+
+TEST_F (ExchangePaths, RoundTripForTwoPaths) {
+    // The output from the export phase.
+    pstore::exchange::export_ns::ostringstream exported_names_stream;
+
+    // The export phase. We put two strings into the paths index and export it.
+    {
+        std::array<pstore::gsl::czstring, 2> paths{{"path1", "path2"}};
+        std::unordered_map<std::string, pstore::typed_address<pstore::indirect_string>>
+            indir_strings;
+        add_export_strings<pstore::trailer::indices::path> (
+            export_db_, std::begin (paths), std::end (paths),
+            std::inserter (indir_strings, std::end (indir_strings)));
+
+        // Write the paths that we just created as JSON.
+        pstore::exchange::export_ns::name_mapping exported_names{
+            export_db_, pstore::exchange::export_ns::path_index_tag ()};
+        pstore::exchange::export_ns::emit_strings<pstore::trailer::indices::path> (
+            exported_names_stream, pstore::exchange::export_ns::indent{}, export_db_,
+            export_db_.get_current_revision (), &exported_names);
+    }
+
+    // The output from the import phase: the mapping from path index to address.
+    pstore::exchange::import::name_mapping imported_names;
+
+    // The import phase. Read the JSON produced by the export phase and populate a database
+    // accordingly.
+    {
+        mock_mutex mutex;
+        auto transaction = begin (import_db_, transaction_lock{mutex});
+        {
+            auto name_parser = import_name_parser (&transaction, &imported_names);
+            name_parser.input (exported_names_stream.str ()).eof ();
+            ASSERT_FALSE (name_parser.has_error ())
+                << "JSON error was: " << name_parser.last_error ().message () << ' '
+                << name_parser.coordinate () << '\n'
+                << exported_names_stream.str ();
+        }
+        transaction.commit ();
+    }
+
+    // Now verify the result of the import phase.
+    std::list<std::string> out;
+    ASSERT_EQ (imported_names.size (), 2U);
+
+    {
+        auto const str_addr_or_err = imported_names.lookup (0U);
+        ASSERT_EQ (str_addr_or_err.get_error (), std::error_code{});
+        pstore::shared_sstring_view owner;
+        out.push_back (get_sstring_view (import_db_, *str_addr_or_err, &owner).to_string ());
+    }
+    {
+        auto const str_addr_or_err = imported_names.lookup (1U);
+        ASSERT_EQ (str_addr_or_err.get_error (), std::error_code{});
+        pstore::shared_sstring_view owner;
+        out.push_back (get_sstring_view (import_db_, *str_addr_or_err, &owner).to_string ());
+    }
+
+    EXPECT_THAT (out, testing::UnorderedElementsAre ("path1", "path2"));
+    EXPECT_EQ (imported_names.lookup (2U), pstore::exchange::import::error::no_such_name);
+}

--- a/unittests/exchange/test_paths.cpp
+++ b/unittests/exchange/test_paths.cpp
@@ -1,3 +1,18 @@
+//===- unittests/exchange/test_paths.cpp ----------------------------------===//
+//*              _   _          *
+//*  _ __   __ _| |_| |__  ___  *
+//* | '_ \ / _` | __| '_ \/ __| *
+//* | |_) | (_| | |_| | | \__ \ *
+//* | .__/ \__,_|\__|_| |_|___/ *
+//* |_|                         *
+//===----------------------------------------------------------------------===//
+//
+// Part of the pstore project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://github.com/SNSystems/pstore/blob/master/LICENSE.txt for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
 #include "pstore/exchange/export_names.hpp"
 #include "pstore/exchange/import_names.hpp"
 

--- a/unittests/exchange/test_section_fixups.cpp
+++ b/unittests/exchange/test_section_fixups.cpp
@@ -320,7 +320,8 @@ TEST_F (ExchangeExternalFixups, ExternalEmpty) {
 
     // Export the internal fixup array to the 'os' string-stream.
     pstore::exchange::export_ns::ostringstream os;
-    pstore::exchange::export_ns::name_mapping names{export_db_};
+    pstore::exchange::export_ns::name_mapping names{export_db_,
+                                                    pstore::exchange::export_ns::name_index_tag ()};
     emit_external_fixups (os, pstore::exchange::export_ns::indent{}, export_db_, names,
                           std::begin (xfixups), std::end (xfixups), false);
 
@@ -342,20 +343,23 @@ TEST_F (ExchangeExternalFixups, ExternalEmpty) {
 }
 
 TEST_F (ExchangeExternalFixups, RoundTripForTwoFixups) {
+    constexpr auto name_index = pstore::trailer::indices::name;
     std::vector<pstore::gsl::czstring> strings{"foo", "bar"};
 
     // Add these strings to the database.
     std::unordered_map<std::string, string_address> indir_strings;
-    add_export_strings (export_db_, std::begin (strings), std::end (strings),
-                        std::inserter (indir_strings, std::end (indir_strings)));
+    add_export_strings<name_index> (export_db_, std::begin (strings), std::end (strings),
+                                    std::inserter (indir_strings, std::end (indir_strings)));
 
 
 
     // Write the names that we just created as JSON.
-    pstore::exchange::export_ns::name_mapping exported_names{export_db_};
+    pstore::exchange::export_ns::name_mapping exported_names{
+        export_db_, pstore::exchange::export_ns::name_index_tag ()};
     pstore::exchange::export_ns::ostringstream exported_names_stream;
-    emit_names (exported_names_stream, pstore::exchange::export_ns::indent{}, export_db_,
-                export_db_.get_current_revision (), &exported_names);
+    pstore::exchange::export_ns::emit_strings<name_index> (
+        exported_names_stream, pstore::exchange::export_ns::indent{}, export_db_,
+        export_db_.get_current_revision (), &exported_names);
 
 
 

--- a/unittests/mcrepo/test_compilation.cpp
+++ b/unittests/mcrepo/test_compilation.cpp
@@ -35,9 +35,8 @@ namespace {
 
 TEST_F (CompilationTest, Empty) {
     std::vector<definition> m;
-    pstore::extent<compilation> extent =
-        compilation::alloc (transaction_, indirect_string_address (0U),
-                            indirect_string_address (0U), std::begin (m), std::end (m));
+    pstore::extent<compilation> extent = compilation::alloc (
+        transaction_, indirect_string_address (0U), std::begin (m), std::end (m));
     auto t = reinterpret_cast<compilation const *> (extent.addr.absolute ());
 
     PSTORE_ASSERT (transaction_.get_storage ().begin ()->first ==
@@ -49,7 +48,6 @@ TEST_F (CompilationTest, Empty) {
 }
 
 TEST_F (CompilationTest, SingleMember) {
-    constexpr auto output_file_path = indirect_string_address (61U);
     constexpr auto triple = indirect_string_address (67U);
     constexpr auto digest = pstore::index::digest{28U};
     constexpr auto extent = pstore::extent<pstore::repo::fragment> (
@@ -61,13 +59,12 @@ TEST_F (CompilationTest, SingleMember) {
     definition sm{digest, extent, name, linkage, visibility};
 
     std::vector<definition> v{sm};
-    compilation::alloc (transaction_, output_file_path, triple, std::begin (v), std::end (v));
+    compilation::alloc (transaction_, triple, std::begin (v), std::end (v));
 
     auto t = reinterpret_cast<compilation const *> (transaction_.get_storage ().begin ()->first);
 
     EXPECT_EQ (1U, t->size ());
     EXPECT_FALSE (t->empty ());
-    EXPECT_EQ (output_file_path, t->path ());
     EXPECT_EQ (triple, t->triple ());
     EXPECT_EQ (sizeof (compilation), t->size_bytes ());
     EXPECT_EQ (digest, (*t)[0].digest);
@@ -78,7 +75,6 @@ TEST_F (CompilationTest, SingleMember) {
 }
 
 TEST_F (CompilationTest, MultipleMembers) {
-    constexpr auto output_file_path = indirect_string_address (32U);
     constexpr auto triple = indirect_string_address (33U);
     constexpr auto digest1 = pstore::index::digest{128U};
     constexpr auto digest2 = pstore::index::digest{144U};
@@ -94,7 +90,7 @@ TEST_F (CompilationTest, MultipleMembers) {
     definition mm2{digest2, extent2, name + 24U, linkage, visibility};
 
     std::vector<definition> v{mm1, mm2};
-    compilation::alloc (transaction_, output_file_path, triple, std::begin (v), std::end (v));
+    compilation::alloc (transaction_, triple, std::begin (v), std::end (v));
 
     auto t = reinterpret_cast<compilation const *> (transaction_.get_storage ().begin ()->first);
 

--- a/utils/exchange_schema/pstore.schema.json
+++ b/utils/exchange_schema/pstore.schema.json
@@ -184,6 +184,13 @@
                         "uniqueItems": true
                     },
 
+                    "paths" : {
+                        "description": "The compilation paths defined by this transaction",
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "uniqueItems": true
+                    },
+
                     "debugline": {
                         "description": "Index associating a digest with a DWARF debug-line header",
                         "type": "object",
@@ -238,7 +245,6 @@
                                 "description": "A compilation defining a collection of symbols",
                                 "type": "object",
                                 "properties": {
-                                    "path": { "type": "number" },
                                     "triple": { "type": "number" },
                                     "definitions": {
                                         "type": "array",
@@ -267,7 +273,7 @@
                                         }
                                     }
                                 },
-                                "required": ["definitions", "path", "triple" ]
+                                "required": ["definitions", "triple" ]
                             }
                         },
                         "additionalProperties": false


### PR DESCRIPTION
Part of a fix for llvm-project-prepo [issue #133](https://github.com/SNSystems/llvm-project-prepo/issues/133).

In this change I add a new index to the repo which contains the set of ticket file paths. This will be a set of indirect-strings (as in the names index). Instead of the ticket file path being recorded as a member of the compilation, tools which write ticket files now simply place an entry containing the full, real (i.e. with intermediate links records), directory path for the file in the paths index.

The dumps and exchange tools (including the export schema) are updated.