### PR TITLE
Add a 'no-disassembly' switch to pstore-dump.

### DIFF
--- a/include/pstore/dump/parameter.hpp
+++ b/include/pstore/dump/parameter.hpp
@@ -34,15 +34,15 @@ namespace pstore {
 
         struct parameters {
             parameters (database const & db_, bool const hex_mode_, bool const expanded_addresses_,
-                        bool const no_times_, std::string const & triple_)
+                        bool const no_times_, bool const no_disassembly_,
+                        std::string const & triple_)
                     : db{db_}
                     , hex_mode{hex_mode_}
                     , expanded_addresses{expanded_addresses_}
-                    , no_times {
-                no_times_
-            }
+                    , no_times{no_times_}
+                    , no_disassembly{no_disassembly_}
 #ifdef PSTORE_IS_INSIDE_LLVM
-            , triple { triple_ }
+                    , triple {triple_}
 #endif
             { (void) triple_; }
             parameters (parameters const &) = delete;
@@ -55,6 +55,7 @@ namespace pstore {
             bool const hex_mode;
             bool const expanded_addresses;
             bool const no_times;
+            bool const no_disassembly;
 #ifdef PSTORE_IS_INSIDE_LLVM
             llvm::Triple const triple;
 #endif

--- a/include/pstore/dump/parameter.hpp
+++ b/include/pstore/dump/parameter.hpp
@@ -40,9 +40,9 @@ namespace pstore {
                     , hex_mode{hex_mode_}
                     , expanded_addresses{expanded_addresses_}
                     , no_times{no_times_}
-                    , no_disassembly{no_disassembly_}
 #ifdef PSTORE_IS_INSIDE_LLVM
-                    , triple {triple_}
+                    , no_disassembly{no_disassembly_}
+                    , triple{triple_}
 #endif
             { (void) triple_; }
             parameters (parameters const &) = delete;
@@ -55,8 +55,8 @@ namespace pstore {
             bool const hex_mode;
             bool const expanded_addresses;
             bool const no_times;
-            bool const no_disassembly;
 #ifdef PSTORE_IS_INSIDE_LLVM
+            bool const no_disassembly;
             llvm::Triple const triple;
 #endif
         };

--- a/lib/dump/mcdisassembler_value.cpp
+++ b/lib/dump/mcdisassembler_value.cpp
@@ -391,6 +391,10 @@ namespace pstore {
         value_ptr make_disassembled_value (std::uint8_t const * const first,
                                            std::uint8_t const * const last,
                                            parameters const & parm) {
+            if (parm.no_disassembly) {
+                return make_hex_dump_value (first, last, parm);
+            }
+
             array::container arr;
             if (!disasm_block (gsl::make_span (first, last), arr, parm)) {
                 return make_value (arr);

--- a/tools/dump/main.cpp
+++ b/tools/dump/main.cpp
@@ -376,8 +376,8 @@ int main (int argc, char * argv[]) {
                                make_value (object::container{{"path", make_value (path)},
                                                              {"size", make_value (db.size ())}}));
 
-            pstore::dump::parameters parm{db, opt.hex, opt.expanded_addresses, opt.no_times,
-                                          opt.triple};
+            pstore::dump::parameters parm{
+                db, opt.hex, opt.expanded_addresses, opt.no_times, opt.no_disassembly, opt.triple};
 
             show_index<pstore::trailer::indices::fragment, dump_error_code::fragment_not_found,
                        dump_error_code::no_fragment_index> (

--- a/tools/dump/switches.cpp
+++ b/tools/dump/switches.cpp
@@ -123,9 +123,14 @@ namespace {
                                  desc{"Emit address values as an explicit segment/offset object"},
                                  cat (how_cat)};
 
+#ifdef PSTORE_IS_INSIDE_LLVM
     opt<std::string> triple{"triple",
                             desc{"The target triple to use for disassembly if one is not known"},
                             init ("x86_64-pc-linux-gnu-repo"), cat (how_cat)};
+    opt<bool> no_disassembly{"no-disassembly",
+                             desc{"Emit executable sections as binary rather than disassembly"},
+                             cat (how_cat)};
+#endif // PSTORE_IS_INSIDE_LLVM
 
     list<std::string> paths{positional, usage{"filename..."}};
 
@@ -170,7 +175,10 @@ std::pair<switches, int> get_switches (int argc, tchar * argv[]) {
     result.hex = hex.get ();
     result.no_times = no_times.get ();
     result.expanded_addresses = expanded_addresses.get ();
+#ifdef PSTORE_IS_INSIDE_LLVM
     result.triple = triple.get ();
+    result.no_disassembly = no_disassembly.get ();
+#endif // PSTORE_IS_INSIDE_LLVM
     result.paths = paths.get ();
 
     return {result, EXIT_SUCCESS};

--- a/tools/dump/switches.hpp
+++ b/tools/dump/switches.hpp
@@ -60,6 +60,7 @@ struct switches {
     bool hex = false;
     bool expanded_addresses = false;
     bool no_times = false;
+    bool no_disassembly = false;
 
     std::list<std::string> paths;
 };


### PR DESCRIPTION
When compiled inside LLVM, pstore-dump makes use of the available libraries to show nice disassembled contents of executable sections. However, there are times when its also useful to be able to see the binary contents of those same sections. This change adds a switch to enable this.