### PR TITLE
Fix for a crash when reporting an HTTP error to the client

### DIFF
--- a/lib/http/server.cpp
+++ b/lib/http/server.cpp
@@ -124,7 +124,7 @@ namespace {
         auto const status_line = build_status_line (error_no, "OK");
 
         auto const content_length = std::to_string (content_str.length ());
-        std::array<czstring_pair, 6> const h{{
+        std::array<czstring_pair, 5> const h{{
             {"Content-length", content_length.c_str ()},
             {"Connection", "close"}, // TODO remove this when we support persistent connections
             {"Content-type", "text/html"},
@@ -213,7 +213,7 @@ namespace {
         return sender (io, as_bytes (pstore::gsl::make_span (response_string))) >>=
                [&sender] (IO io2) {
                    auto const ws_version = std::to_string (pstore::http::ws_version);
-                   std::array<czstring_pair, 2> const headers{{
+                   std::array<czstring_pair, 1> const headers{{
                        {"Sec-WebSocket-Version", ws_version.c_str ()},
                    }};
                    std::string const h = build_headers (std::begin (headers), std::end (headers));


### PR DESCRIPTION
Commit bd357fa2b726f6d292f8d57644609dc854a74896 created a unified HTTP error code scheme and replaced a series of blocks of hand-coded operations to construct HTTP headers with a single function responsible for doing the job. It takes a range of czstring pairs and returns a std::string with the correctly expanded header block.

Unfortunately, I managed to get the construction of this range wrong in three places. The first of those was fixed by commit 9b00d4cd67e9735742293210b2a3ab1a3919b521. This commit fixes the same error in two more places. It seems that I can’t count.

I really need to move cerror() and the functions it calls to a new module and add some unit tests for them. That’s beyond the scope of this fix.