### PR TITLE
Fix for crash if parse_command_line_options() is called twice.

### DIFF
--- a/include/pstore/command_line/option.hpp
+++ b/include/pstore/command_line/option.hpp
@@ -135,6 +135,19 @@ namespace pstore {
             explicit option (num_occurrences_flag occurrences);
 
         private:
+            /// The location of this entry in the (global) options list. This iterator is a
+            /// reference into the list returned by the option::all() function. It's used simply to
+            /// remove the option from that container when the former is destroyed.
+            options_container::const_iterator container_pos_;
+
+            /// Adds the supplied option instance to the global container and returns a iterator
+            /// which references it.
+            ///
+            /// \param opt  The option to be added to the global container.
+            /// \returns  An iterator referencing the global option list which will yield opt when
+            ///   dereferenced.
+            static options_container::const_iterator add_to_global_list (option * const opt);
+
             std::string name_;
             std::string usage_;
             std::string description_;

--- a/lib/command_line/option.cpp
+++ b/lib/command_line/option.cpp
@@ -32,13 +32,31 @@ namespace pstore {
             //* / _ \ '_ \  _| / _ \ ' \  *
             //* \___/ .__/\__|_\___/_||_| *
             //*     |_|                   *
-            option::option () { all ().push_back (this); }
+            // (ctor)
+            // ~~~~~~
+            option::option ()
+                    : container_pos_{option::add_to_global_list (this)} {}
             option::option (num_occurrences_flag const occurrences)
                     : option () {
                 occurrences_ = occurrences;
             }
 
-            option::~option () = default;
+            // (dtor)
+            // ~~~~~~
+            option::~option () {
+                // Remove this option from the global container.
+                options_container & all = option::all ();
+                all.erase (container_pos_);
+            }
+
+            // add to global list
+            // ~~~~~~~~~~~~~~~~~~
+            auto option::add_to_global_list (option * const opt)
+                -> options_container::const_iterator {
+                options_container & all = option::all ();
+                all.push_back (opt);
+                return std::prev (all.end ());
+            }
 
             void option::set_num_occurrences_flag (num_occurrences_flag const n) {
                 occurrences_ = n;

--- a/unittests/command_line/test_command_line.cpp
+++ b/unittests/command_line/test_command_line.cpp
@@ -467,3 +467,22 @@ TEST_F (ClCommandLine, AliasBool) {
     EXPECT_EQ (opt.get (), true);
     EXPECT_EQ (opt2.get_num_occurrences (), 1U);
 }
+
+TEST_F (ClCommandLine, TwoCallsToParser) {
+    opt<std::string> option ("S");
+    this->add ("progname", "-Svalue");
+
+    string_stream output;
+    string_stream errors;
+    bool const res1 = this->parse_command_line_options (output, errors);
+    EXPECT_TRUE (res1);
+    bool const res2 = this->parse_command_line_options (output, errors);
+    EXPECT_TRUE (res2);
+
+    EXPECT_EQ (errors.str ().length (), 0U);
+    EXPECT_EQ (output.str ().length (), 0U);
+
+    EXPECT_EQ (option.get (), "value");
+    // We saw the -S switch twice because the arguments were parsed twice.
+    EXPECT_EQ (option.get_num_occurrences (), 2U);
+}

--- a/unittests/command_line/test_modifiers.cpp
+++ b/unittests/command_line/test_modifiers.cpp
@@ -65,41 +65,48 @@ namespace {
 
     class EnumerationParse : public testing::Test {
     public:
-        EnumerationParse ()
-                : enum_opt_{
-                      "enumeration",
-                      values (literal{"a", static_cast<int> (enumeration::a), "a description"},
-                              literal{"b", static_cast<int> (enumeration::b), "b description"},
-                              literal{"c", static_cast<int> (enumeration::c), "c description"})} {}
+        EnumerationParse () = default;
         ~EnumerationParse () override { option::reset_container (); }
-
-    protected:
-        opt<enumeration> enum_opt_;
     };
 
 } // end anonymous namespace
 
 TEST_F (EnumerationParse, SetA) {
+    opt<enumeration> enum_opt{
+        "enumeration", values (literal{"a", static_cast<int> (enumeration::a), "a description"},
+                               literal{"b", static_cast<int> (enumeration::b), "b description"},
+                               literal{"c", static_cast<int> (enumeration::c), "c description"})};
+
     std::vector<std::string> argv{"progname", "--enumeration=a"};
     string_stream output;
     string_stream errors;
     bool ok = details::parse_command_line_options (std::begin (argv), std::end (argv), "overview",
                                                    output, errors);
     ASSERT_TRUE (ok);
-    ASSERT_EQ (enum_opt_.get (), enumeration::a);
+    ASSERT_EQ (enum_opt.get (), enumeration::a);
 }
 
 TEST_F (EnumerationParse, SetC) {
+    opt<enumeration> enum_opt{
+        "enumeration", values (literal{"a", static_cast<int> (enumeration::a), "a description"},
+                               literal{"b", static_cast<int> (enumeration::b), "b description"},
+                               literal{"c", static_cast<int> (enumeration::c), "c description"})};
+
     std::vector<std::string> argv{"progname", "--enumeration=c"};
     string_stream output;
     string_stream errors;
     bool ok = details::parse_command_line_options (std::begin (argv), std::end (argv), "overview",
                                                    output, errors);
     ASSERT_TRUE (ok);
-    ASSERT_EQ (enum_opt_.get (), enumeration::c);
+    ASSERT_EQ (enum_opt.get (), enumeration::c);
 }
 
 TEST_F (EnumerationParse, ErrorBadValue) {
+    opt<enumeration> enum_opt{
+        "enumeration", values (literal{"a", static_cast<int> (enumeration::a), "a description"},
+                               literal{"b", static_cast<int> (enumeration::b), "b description"},
+                               literal{"c", static_cast<int> (enumeration::c), "c description"})};
+
     std::vector<std::string> argv{"progname", "--enumeration=bad"};
     string_stream output;
     string_stream errors;
@@ -110,6 +117,11 @@ TEST_F (EnumerationParse, ErrorBadValue) {
 }
 
 TEST_F (EnumerationParse, GoodValueAfterError) {
+    opt<enumeration> enum_opt{
+        "enumeration", values (literal{"a", static_cast<int> (enumeration::a), "a description"},
+                               literal{"b", static_cast<int> (enumeration::b), "b description"},
+                               literal{"c", static_cast<int> (enumeration::c), "c description"})};
+
     std::vector<std::string> argv{"progname", "--unknown", "--enumeration=a"};
     string_stream output;
     string_stream errors;


### PR DESCRIPTION
One of the forms of parse_command_line_options() implicitly added an option for the '--help' switch. This object is on the function’s stack. Unfortunately, the option ctor adds the object to the global options list. If this list was not reset before calling parse_command_line_options() a second time, it would contain a dangling pointer to that original '--help' instance and we crash.

To fix the problem, we now remove options from the global list in their dtor. This avoids the dangling pointer.

Added a unit test for this case. Updated the EnumerationParse test because the option instance must be alive when reset_container() is called.

The use of a global list remains far from ideal, though...
