### PR TITLE
Support building thread_posix.cpp using the musl-prepo libc library.

### DIFF
--- a/lib/os/thread_posix.cpp
+++ b/lib/os/thread_posix.cpp
@@ -29,11 +29,15 @@
 // OS-specific includes
 #    include <pthread.h>
 
-#    ifdef __linux__
+
+#    ifdef PSTORE_HAVE_LINUX_UNISTD_H
 #        include <linux/unistd.h>
-#        include <sys/syscall.h>
-#        include <unistd.h>
 #    endif
+#    ifdef PSTORE_HAVE_SYS_SYSCALL_H
+#        include <sys/syscall.h>
+#    endif
+#    include <unistd.h>
+
 #    ifdef __FreeBSD__
 #        include <pthread_np.h>
 #    endif
@@ -44,10 +48,28 @@
 
 namespace pstore {
     namespace threads {
+#    if defined(PSTORE_PTHREAD_SETNAME_NP_1_ARG) || defined(PSTORE_PTHREAD_SETNAME_NP_2_ARGS) ||   \
+        defined(PSTORE_PTHREAD_SETNAME_NP_3_ARGS) || defined(PSTORE_PTHREAD_SET_NAME_NP)
+#        define PTHREAD_SETNAME_NP 1
+#    endif
 
-#    ifdef __FreeBSD__
+#    if defined(PSTORE_PTHREAD_GETNAME_NP) || defined(PSTORE_PTHREAD_GET_NAME_NP)
+#        define PTHREAD_GETNAME_NP 1
+#    endif
+
+// FIXME: The current musl libc library only includes the function `pthread_setname_np` but not
+// supports `pthread_getname_np` yet. Therefore, we use the fall back if either function is missing.
+// We will revisit when a version of musl supporting `pthread_getname_np` is released. Once musl
+// libc supports both functions, we could change the codes to use the fall back if both functions
+// aren’t supported. If there is a mismatch, we would like the compile to fail with a #error to
+// check whether there may be something to fix with the platform support.
+#    if !defined(PTHREAD_SETNAME_NP) || !defined(PTHREAD_SETNAME_NP)
+#        define USE_FALLBACK 1
+#    endif
+
+#    ifdef USE_FALLBACK
         static thread_local char thread_name[name_size];
-#    endif // __FreeBSD__
+#    endif
 
         void set_name (gsl::not_null<gsl::czstring> const name) {
             // pthread support for setting thread names comes in various non-portable forms.
@@ -56,26 +78,22 @@ namespace pstore {
             // - two argument form supported by Linux.
             // - three argument form supported by NetBSD.
             // - the slightly differently named form used in FreeBSD.
-#    ifdef __FreeBSD__
+            int err = 0;
+#    ifdef USE_FALLBACK
             std::strncpy (thread_name, name, name_size);
             thread_name[name_size - 1] = '\0';
-#    else
-            int err = 0;
-#        if defined(PSTORE_PTHREAD_SETNAME_NP_1_ARG)
+#    elif defined(PSTORE_PTHREAD_SETNAME_NP_1_ARG)
             err = pthread_setname_np (name);
-#        elif defined(PSTORE_PTHREAD_SETNAME_NP_2_ARGS)
+#    elif defined(PSTORE_PTHREAD_SETNAME_NP_2_ARGS)
             err = pthread_setname_np (pthread_self (), name);
-#        elif defined(PSTORE_PTHREAD_SETNAME_NP_3_ARGS)
+#    elif defined(PSTORE_PTHREAD_SETNAME_NP_3_ARGS)
             err = pthread_setname_np (pthread_self (), name, nullptr);
-#        elif defined(PSTORE_PTHREAD_SET_NAME_NP)
+#    elif defined(PSTORE_PTHREAD_SET_NAME_NP)
             pthread_set_name_np (pthread_self (), name);
-#        else
-#            error "pthread_setname was not available"
-#        endif
+#    endif
             if (err != 0) {
                 raise (errno_erc{err}, "pthread_set_name_np");
             }
-#    endif // __FreeBSD__
         }
 
         gsl::czstring get_name (gsl::span<char, name_size> const name /*out*/) {
@@ -83,16 +101,21 @@ namespace pstore {
             if (name.data () == nullptr || length < 1) {
                 raise (errno_erc{EINVAL});
             }
-#    ifdef __FreeBSD__
-            std::strncpy (name.data (), thread_name, static_cast<std::size_t> (length));
-#    else
+
             PSTORE_ASSERT (length == name.size_bytes ());
-            int const err = pthread_getname_np (pthread_self (), name.data (),
-                                                static_cast<std::size_t> (length));
+            int err = 0;
+#    ifdef USE_FALLBACK
+            std::strncpy (name.data (), thread_name, static_cast<std::size_t> (length));
+#    elif defined(PSTORE_PTHREAD_GETNAME_NP)
+            err = pthread_getname_np (pthread_self (), name.data (),
+                                      static_cast<std::size_t> (length));
+#    elif defined(PSTORE_PTHREAD_GET_NAME_NP)
+            err = pthread_get_name_np (pthread_self (), name.data (),
+                                       static_cast<std::size_t> (length));
+#    endif
             if (err != 0) {
                 raise (errno_erc{err}, "pthread_getname_np");
             }
-#    endif // __FreeBSD__
             name[length - 1] = '\0';
             return name.data ();
         }

--- a/lib/support/CMakeLists.txt
+++ b/lib/support/CMakeLists.txt
@@ -43,6 +43,7 @@ endif ()
 check_include_files ("byteswap.h" PSTORE_HAVE_BYTESWAP_H)
 check_include_files ("linux/fs.h" PSTORE_HAVE_LINUX_FS_H)
 check_include_files ("linux/limits.h" PSTORE_HAVE_LINUX_LIMITS_H)
+check_include_files ("linux/unistd.h" PSTORE_HAVE_LINUX_UNISTD_H)
 check_include_files ("sys/endian.h" PSTORE_HAVE_SYS_ENDIAN_H)
 check_include_files ("sys/syscall.h" PSTORE_HAVE_SYS_SYSCALL_H)
 check_include_files ("sys/time.h;sys/types.h;sys/posix_shm.h" PSTORE_HAVE_SYS_POSIX_SHM_H)
@@ -222,6 +223,27 @@ check_cxx_source_compiles (
         pthread_set_name_np (pthread_self (), \"foo\");
     }"
     PSTORE_PTHREAD_SET_NAME_NP)
+
+check_cxx_source_compiles (
+    "#include <pthread.h>
+    #ifdef __FreeBSD__
+    #include <pthread_np.h>
+    #endif
+    int main () {
+        pthread_getname_np (pthread_self (), \"foo\", 4);
+    }"
+    PSTORE_PTHREAD_GETNAME_NP)
+
+check_cxx_source_compiles (
+    "#include <pthread.h>
+    #ifdef __FreeBSD__
+    #include <pthread_np.h>
+    #endif
+    int main () {
+        pthread_get_name_np (pthread_self (), \"foo\", 4);
+    }"
+    PSTORE_PTHREAD_GET_NAME_NP)
+
 set (CMAKE_REQUIRED_LIBRARIES )
 
 check_cxx_source_compiles (
@@ -230,7 +252,6 @@ check_cxx_source_compiles (
         return _NSGetExecutablePath (0, 0);
     }"
     PSTORE_HAVE_NSGETEXECUTABLEPATH)
-
 
 configure_file (
     "${CMAKE_CURRENT_SOURCE_DIR}/config.hpp.in"

--- a/lib/support/config.hpp.in
+++ b/lib/support/config.hpp.in
@@ -57,6 +57,9 @@
 /// Defined if <sys/syscall.h> is available.
 #cmakedefine PSTORE_HAVE_SYS_SYSCALL_H 1
 
+/// Defined if <linux/unistd.h> is available.
+#cmakedefine PSTORE_HAVE_LINUX_UNISTD_H 1
+
 /// Defined if the C11 localtime_s() API is available.
 #cmakedefine PSTORE_HAVE_LOCALTIME_S 1
 
@@ -80,6 +83,12 @@
 #cmakedefine PSTORE_PTHREAD_SETNAME_NP_2_ARGS 1
 #cmakedefine PSTORE_PTHREAD_SETNAME_NP_3_ARGS 1
 #cmakedefine PSTORE_PTHREAD_SET_NAME_NP 1
+
+/// Defined if the `pthread_getname_np' function is available.
+#cmakedefine PSTORE_PTHREAD_GETNAME_NP 1
+
+/// Defined if the `pthread_get_name_np' function is available.
+#cmakedefine PSTORE_PTHREAD_GET_NAME_NP 1
 
 /// Is the macOS _NSGetExecutablePath() function available?
 #cmakedefine PSTORE_HAVE_NSGETEXECUTABLEPATH 1


### PR DESCRIPTION
When I build the pstore-write project using musl libc library, I got the following errors:

```
/home/maggie/github/llvm-project-prepo/pstore/lib/os/thread_posix.cpp:73:14: error: "pthread_setname was not available"
#            error "pthread_setname was not available"
             ^
/home/maggie/github/llvm-project-prepo/pstore/lib/os/thread_posix.cpp:52:59: warning: unused parameter 'name' [-Wunused-parameter]
        void set_name (gsl::not_null<gsl::czstring> const name) {
                                                          ^
/home/maggie/github/llvm-project-prepo/pstore/lib/os/thread_posix.cpp:90:29: error: use of undeclared identifier 'pthread_getname_np'
            int const err = pthread_getname_np (pthread_self (), name.data (),
```

The musl-prepo libc library only includes the `thread_setname_np` function but not `thread_getname_np` because there are multiple incompatible historical functions by the same name. 

Following Paul's advice, the changes include:

1. At `configure` time in the CMake script, the `thread_getname_np` function should test whether the function is available and define a macro accordingly. Then the code can choose whether to use the function or to use a fallback.
2. FreeBSD currently supports the functions `pthread_set_name_np()`  and p`thread_get_name_np. Change the code using these two functions instead of the fallback.
3. Move the existing fallback to the `else` case.