### PR TITLE
chunked_vector<> resize

### DIFF
--- a/include/pstore/adt/chunked_vector.hpp
+++ b/include/pstore/adt/chunked_vector.hpp
@@ -428,7 +428,7 @@ namespace pstore {
     template <typename T, std::size_t ElementsPerChunk, std::size_t ActualSize,
               std::size_t ActualAlign>
     void chunked_vector<T, ElementsPerChunk, ActualSize, ActualAlign>::chunk::shrink (
-        std::size_t new_size) noexcept {
+        std::size_t const new_size) noexcept {
         assert (new_size <= size_);
         for (auto ctr = new_size; ctr < size_; ++ctr) {
             (*this)[ctr].~T ();

--- a/include/pstore/adt/chunked_vector.hpp
+++ b/include/pstore/adt/chunked_vector.hpp
@@ -35,6 +35,12 @@ namespace pstore {
     /// ensure very fast append times at the expense of only permitting bi-directional iterators:
     /// random access is not supported, unlike std::deque<> or std::vector<>.
     ///
+    /// Each chunk has storage for a number of objects. This number is a compile-time constant and
+    /// is usually reasonably large and chosen so that the memory required is a multiple of the VM
+    /// page size. Appending is performed in amortized constant time where we either bump a pointer
+    /// in an existing chunk or allocate a new one. Unlike std::vector<>, no moving or copying
+    /// occurs after append, and only the past-the-end iterator is invalidated.
+    ///
     /// \tparam T The type of the elements.
     /// \tparam ElementsPerChunk The number of elements in an individual chunk.
     /// \tparam ActualSize The storage allocated to an individual element. Normally equal to
@@ -183,7 +189,7 @@ namespace pstore {
                                               ChunkedVector, iterator, const_iterator>::type>
         static Result end_impl (ChunkedVector & cv) noexcept;
 
-        /// Add default-initialized member to increase the number of elements held in the container
+        /// Add default-initialized members to increase the number of elements held in the container
         /// to \p count.
         ///
         /// \param count  The number of elements in the container after the resize operation.

--- a/include/pstore/adt/chunked_vector.hpp
+++ b/include/pstore/adt/chunked_vector.hpp
@@ -68,6 +68,9 @@ namespace pstore {
         // using reverse_iterator =
         // using const_reverse_iterator =
 
+        /// The number of elements in an individual chunk.
+        static constexpr std::size_t elements_per_chunk = ElementsPerChunk;
+
         chunked_vector ();
         chunked_vector (chunked_vector const &) = delete;
         chunked_vector (chunked_vector && other) noexcept;
@@ -100,7 +103,27 @@ namespace pstore {
         void reserve (std::size_t const /*size*/) {
             // TODO: Not currently implemented.
         }
+
+        /// Returns the number of elements that the container has currently allocated space for.
+        ///
+        /// \returns Capacity of the currently allocated storage.
         std::size_t capacity () const noexcept { return chunks_.size () * ElementsPerChunk; }
+
+        /// \brief Resizes the container to contain count elements.
+        ///
+        /// If the current size is greater than count, the container is reduced to its first \p
+        /// count elements. If the current size is less than \p count, additional default-inserted
+        /// elements are appended.
+        ///
+        /// \param count  The new size of the container.
+        void resize (size_type count) {
+            if (count > size_) {
+                return this->resize_grow (count);
+            }
+            if (count < size_) {
+                this->resize_shrink (count);
+            }
+        }
 
         template <typename... Args>
         reference emplace_back (Args &&... args);
@@ -160,6 +183,17 @@ namespace pstore {
                                               ChunkedVector, iterator, const_iterator>::type>
         static Result end_impl (ChunkedVector & cv) noexcept;
 
+        /// Add default-initialized member to increase the number of elements held in the container
+        /// to \p count.
+        ///
+        /// \param count  The number of elements in the container after the resize operation.
+        void resize_grow (size_type count);
+
+        /// Remove elements from the end of the container so that it contains \p count members.
+        ///
+        /// \param count  The number of elements in the container after the resize operation.
+        void resize_shrink (size_type count);
+
         chunk_list chunks_;
         size_type size_ = 0; ///< The number of elements.
     };
@@ -207,7 +241,6 @@ namespace pstore {
         return *this;
     }
 
-
     // emplace back
     // ~~~~~~~~~~~~
     template <typename T, std::size_t ElementsPerChunk, std::size_t ActualSize,
@@ -245,6 +278,75 @@ namespace pstore {
         return cv.begin ();
     }
 
+    // resize grow
+    // ~~~~~~~~~~~
+    template <typename T, std::size_t ElementsPerChunk, std::size_t ActualSize,
+              std::size_t ActualAlign>
+    void
+    chunked_vector<T, ElementsPerChunk, ActualSize, ActualAlign>::resize_grow (size_type count) {
+        auto const grow_chunk = [this] (chunk * const c, std::size_t const limit) {
+            assert (limit <= c->capacity ());
+            for (auto ctr = limit; ctr > 0U; --ctr) {
+                c->emplace_back ();
+                // Increment size each time in case emplace_back() throws.
+                ++size_;
+            }
+            return limit;
+        };
+
+        if (count <= size_) {
+            return; // Nothing to do.
+        }
+
+        count -= size_;
+        {
+            // First we must fill the current tail chunk with new default-constructed elements.
+            auto & tail = chunks_.back ();
+            std::size_t const tc = tail.capacity ();
+            // If the last chunk partially occupied? If so, fill the rest of it.
+            std::size_t const limit = std::min (count, tc);
+            count -= grow_chunk (&tail, limit);
+            assert (tail.capacity () == tc - limit);
+        }
+
+        // Allocate as many chunks as necessary filling them with the correct number of
+        // default-initialized members.
+        while (count > 0U) {
+            // Append a new chunk.
+            chunks_.emplace_back ();
+            // Fill the chunk with default-constructed elements.
+            count -= grow_chunk (&chunks_.back (), std::min (ElementsPerChunk, count));
+        }
+    }
+
+    // resize shrink
+    // ~~~~~~~~~~~~~
+    template <typename T, std::size_t ElementsPerChunk, std::size_t ActualSize,
+              std::size_t ActualAlign>
+    void
+    chunked_vector<T, ElementsPerChunk, ActualSize, ActualAlign>::resize_shrink (size_type count) {
+        if (count >= size_) {
+            return; // Nothing to do.
+        }
+
+        // 'count' becomes the number of elements to remove.
+        count = size_ - count;
+        auto & head = chunks_.front ();
+        while (count > 0U) {
+            auto & tail = chunks_.back ();
+            auto in_chunk = tail.size ();
+            // Note that we don't delete head: there is always at least one chunk.
+            if (count >= in_chunk && &tail != &head) {
+                chunks_.pop_back ();
+            } else {
+                in_chunk = count;
+                tail.shrink (in_chunk);
+            }
+            count -= in_chunk;
+            size_ -= in_chunk;
+        }
+    }
+
     //*     _             _    *
     //*  __| |_ _  _ _ _ | |__ *
     //* / _| ' \ || | ' \| / / *
@@ -277,7 +379,11 @@ namespace pstore {
             PSTORE_ASSERT (index < ElementsPerChunk);
             return reinterpret_cast<T const &> (membs_[index]);
         }
-        std::size_t size () const noexcept { return size_; }
+        constexpr std::size_t size () const noexcept { return size_; }
+
+        constexpr std::size_t capacity () const noexcept {
+            return ElementsPerChunk - this->size ();
+        }
 
         reference front () { return (*this)[0]; }
         const_reference front () const { return (*this)[0]; }
@@ -287,24 +393,23 @@ namespace pstore {
         template <typename... Args>
         reference emplace_back (Args &&... args);
 
+        void shrink (std::size_t new_size) noexcept;
+
     private:
         std::size_t size_ = 0U;
         std::array<typename std::aligned_storage<ActualSize, ActualAlign>::type, ElementsPerChunk>
             membs_;
     };
 
-    // dtor
-    // ~~~~
+    // (dtor)
+    // ~~~~~~
     template <typename T, std::size_t ElementsPerChunk, std::size_t ActualSize,
               std::size_t ActualAlign>
     chunked_vector<T, ElementsPerChunk, ActualSize, ActualAlign>::chunk::~chunk () noexcept {
-        for (auto ctr = std::size_t{0}; ctr < size_; ++ctr) {
-            (*this)[ctr].~T ();
-        }
-        size_ = 0U;
+        this->shrink (0U);
     }
 
-    // emplace_back
+    // emplace back
     // ~~~~~~~~~~~~
     template <typename T, std::size_t ElementsPerChunk, std::size_t ActualSize,
               std::size_t ActualAlign>
@@ -316,6 +421,19 @@ namespace pstore {
         new (&place) T (std::forward<Args> (args)...);
         ++size_;
         return place;
+    }
+
+    // shrink
+    // ~~~~~~
+    template <typename T, std::size_t ElementsPerChunk, std::size_t ActualSize,
+              std::size_t ActualAlign>
+    void chunked_vector<T, ElementsPerChunk, ActualSize, ActualAlign>::chunk::shrink (
+        std::size_t new_size) noexcept {
+        assert (new_size <= size_);
+        for (auto ctr = new_size; ctr < size_; ++ctr) {
+            (*this)[ctr].~T ();
+        }
+        size_ = new_size;
     }
 
     //*  _ _                _             _                   *

--- a/unittests/adt/klee/CMakeLists.txt
+++ b/unittests/adt/klee/CMakeLists.txt
@@ -1,4 +1,4 @@
-#===- unittests/adt/CMakeLists.txt ----------------------------------------===//
+#===- unittests/adt/klee/CMakeLists.txt -----------------------------------===//
 #*   ____ __  __       _        _     _     _        *
 #*  / ___|  \/  | __ _| | _____| |   (_)___| |_ ___  *
 #* | |   | |\/| |/ _` | |/ / _ \ |   | / __| __/ __| *
@@ -13,11 +13,4 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 #===----------------------------------------------------------------------===//
-add_pstore_unit_test (pstore-adt-unit-tests
-    test_chunked_vector.cpp
-    test_error_or.cpp
-    test_small_vector.cpp
-    test_sstring_view.cpp
-)
-target_link_libraries (pstore-adt-unit-tests PRIVATE pstore-adt)
-add_subdirectory (klee EXCLUDE_FROM_ALL)
+add_subdirectory (cv)

--- a/unittests/adt/klee/cv/CMakeLists.txt
+++ b/unittests/adt/klee/cv/CMakeLists.txt
@@ -1,4 +1,4 @@
-#===- unittests/adt/CMakeLists.txt ----------------------------------------===//
+#===- unittests/adt/klee/cv/CMakeLists.txt --------------------------------===//
 #*   ____ __  __       _        _     _     _        *
 #*  / ___|  \/  | __ _| | _____| |   (_)___| |_ ___  *
 #* | |   | |\/| |/ _` | |/ / _ \ |   | / __| __/ __| *
@@ -13,11 +13,4 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 #===----------------------------------------------------------------------===//
-add_pstore_unit_test (pstore-adt-unit-tests
-    test_chunked_vector.cpp
-    test_error_or.cpp
-    test_small_vector.cpp
-    test_sstring_view.cpp
-)
-target_link_libraries (pstore-adt-unit-tests PRIVATE pstore-adt)
-add_subdirectory (klee EXCLUDE_FROM_ALL)
+pstore_add_klee_test (CATEGORY cv NAME resize DEPENDS pstore-adt)

--- a/unittests/adt/klee/cv/resize.cpp
+++ b/unittests/adt/klee/cv/resize.cpp
@@ -38,7 +38,7 @@ namespace {
     void check (pstore::chunked_vector<int, elements_per_chunk> const & cv,
                 std::size_t const size) {
         assert (cv.size () == size);
-        assert (std::distance (std::begin (cv), std::end (cv) == size);
+        assert (std::distance (std::begin (cv), std::end (cv)) == size);
         assert (std::all_of (std::begin (cv), std::end (cv), [] (int x) { return x == 0; }));
     }
 

--- a/unittests/adt/klee/cv/resize.cpp
+++ b/unittests/adt/klee/cv/resize.cpp
@@ -1,0 +1,56 @@
+//===- unittests/adt/klee/cv/resize.cpp -----------------------------------===//
+//*                _          *
+//*  _ __ ___  ___(_)_______  *
+//* | '__/ _ \/ __| |_  / _ \ *
+//* | | |  __/\__ \ |/ /  __/ *
+//* |_|  \___||___/_/___\___| *
+//*                           *
+//===----------------------------------------------------------------------===//
+//
+// Part of the pstore project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://github.com/SNSystems/pstore/blob/master/LICENSE.txt for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+/// \file resize.cpp
+/// \brief KLEE test for chunked_vector<>::resize().
+///
+/// This test makes two calls to resize() both using symbolic arguments. The idea behind this is
+/// that we start with an empty container, resize it and then resize it again. The second of these
+/// resize operations may be a no-op or will enlarge or shrink the container from the starting point
+/// produced by the first resize. This should enable the test to cover all of the possible start and
+/// end conditions.
+
+#include <cassert>
+#include <klee/klee.h>
+#include "pstore/adt/chunked_vector.hpp"
+
+namespace {
+
+    constexpr auto elements_per_chunk = 3U;
+    constexpr auto max_size = elements_per_chunk * 3U;
+
+    void check (pstore::chunked_vector<int, elements_per_chunk> const & cv, std::size_t size) {
+        assert (cv.size () == size);
+        assert (std::all_of (std::begin (cv), std::end (cv), [] (int x) { return x == 0; }));
+    }
+} // namespace
+
+
+int main () {
+    pstore::chunked_vector<int, elements_per_chunk> cv;
+    std::size_t new_size1;
+    std::size_t new_size2;
+    klee_make_symbolic (&new_size1, sizeof (new_size1), "new_size1");
+    klee_make_symbolic (&new_size2, sizeof (new_size2), "new_size2");
+    // Limit the size to < max_size since this should represent more than enough test cases to
+    // exercise every possible code path.
+    klee_assume (new_size1 < max_size);
+    klee_assume (new_size2 < max_size);
+
+    cv.resize (new_size1);
+    check (cv, new_size1);
+    cv.resize (new_size2);
+    check (cv, new_size2);
+}

--- a/unittests/adt/klee/cv/resize.cpp
+++ b/unittests/adt/klee/cv/resize.cpp
@@ -22,8 +22,12 @@
 /// produced by the first resize. This should enable the test to cover all of the possible start and
 /// end conditions.
 
+#include <algorithm>
 #include <cassert>
+#include <iterator>
+
 #include <klee/klee.h>
+
 #include "pstore/adt/chunked_vector.hpp"
 
 namespace {
@@ -31,11 +35,14 @@ namespace {
     constexpr auto elements_per_chunk = 3U;
     constexpr auto max_size = elements_per_chunk * 3U;
 
-    void check (pstore::chunked_vector<int, elements_per_chunk> const & cv, std::size_t size) {
+    void check (pstore::chunked_vector<int, elements_per_chunk> const & cv,
+                std::size_t const size) {
         assert (cv.size () == size);
+        assert (std::distance (std::begin (cv), std::end (cv) == size);
         assert (std::all_of (std::begin (cv), std::end (cv), [] (int x) { return x == 0; }));
     }
-} // namespace
+
+} // end anonymous namespace
 
 
 int main () {

--- a/unittests/adt/test_chunked_vector.cpp
+++ b/unittests/adt/test_chunked_vector.cpp
@@ -237,9 +237,9 @@ TEST (ChunkedVectorResize, FillInitialChunkAndPartialSecond) {
     cvector_int cv;
     cv.emplace_back (17);
     // Before the resize we have a single chunk:
-    //     [ 13, _ ]
+    //     [ 17, _ ]
     // Extending this to three members will produce:
-    //     [ 13, 0 ] -> [ 0, _ ]
+    //     [ 17, 0 ] -> [ 0, _ ]
     cv.resize (3U);
     EXPECT_EQ (cv.size (), 3U);
     EXPECT_EQ (cv.capacity (), 4U);

--- a/unittests/adt/test_chunked_vector.cpp
+++ b/unittests/adt/test_chunked_vector.cpp
@@ -313,3 +313,16 @@ TEST (ChunkedVectorResize, FiveElementsDownToOne) {
     cvector_int::const_iterator it = cv.begin ();
     EXPECT_EQ (*it, 17) << "Element 0 (chunk 0, index 0)";
 }
+
+TEST (ChunkedVectorResize, ThreeElementsDownToZero) {
+    cvector_int cv;
+    cv.emplace_back (37);
+    cv.emplace_back (41);
+    cv.emplace_back (43);
+    // Before: [ 37, 41 ] -> [ 43, _ ]
+    // After: [ _, _ ]
+    cv.resize (0U);
+    EXPECT_EQ (cv.size (), 0U);
+    EXPECT_EQ (cv.capacity (), 2U);
+    EXPECT_TRUE (cv.empty ());
+}

--- a/unittests/adt/test_chunked_vector.cpp
+++ b/unittests/adt/test_chunked_vector.cpp
@@ -29,9 +29,9 @@ namespace {
     // A class which simply wraps and int and doesn't have a default ctor.
     class simple {
     public:
-        explicit simple (int v)
+        constexpr explicit simple (int v) noexcept
                 : v_{v} {}
-        int get () const { return v_; }
+        constexpr int get () const noexcept { return v_; }
 
     private:
         int v_;
@@ -165,7 +165,6 @@ namespace {
     class CVIterator : public testing::Test {
     public:
         CVIterator () {
-            cv_.reserve (4);
             cv_.emplace_back (2);
             cv_.emplace_back (3);
             cv_.emplace_back (5);
@@ -213,4 +212,104 @@ TYPED_TEST (CVIterator, Predecrement) {
     --it;
     EXPECT_EQ (*it, 2);
     EXPECT_EQ (it, this->cv_.begin ());
+}
+
+//  - An underscore '_' indicates uninitialized storage.
+//  - An arrow '->' indicates the list of chunks.
+TEST (ChunkedVectorResize, FillCurrentTailChunk) {
+    cvector_int cv;
+    cv.emplace_back (13);
+    // Before the resize we have a single chunk:
+    //     [ 13, _ ]
+    // After it, we fill the tail chunk with default-initialized int:
+    //    [ 13, 0 ]
+    cv.resize (2U);
+    EXPECT_EQ (cv.size (), 2U);
+    EXPECT_EQ (cv.capacity (), 2U);
+
+    cvector_int::const_iterator it = cv.begin ();
+    EXPECT_EQ (*it, 13) << "Element 0 (chunk 0, index 0)";
+    std::advance (it, 1);
+    EXPECT_EQ (*it, 0) << "Element 0 (chunk 0, index 1)";
+}
+
+TEST (ChunkedVectorResize, FillInitialChunkAndPartialSecond) {
+    cvector_int cv;
+    cv.emplace_back (17);
+    // Before the resize we have a single chunk:
+    //     [ 13, _ ]
+    // Extending this to three members will produce:
+    //     [ 13, 0 ] -> [ 0, _ ]
+    cv.resize (3U);
+    EXPECT_EQ (cv.size (), 3U);
+    EXPECT_EQ (cv.capacity (), 4U);
+
+    cvector_int::const_iterator it = cv.begin ();
+    EXPECT_EQ (*it, 17) << "Element 0 (chunk 0, index 0)";
+    std::advance (it, 1);
+    EXPECT_EQ (*it, 0) << "Element 1 (chunk 0, index 1)";
+    std::advance (it, 1);
+    EXPECT_EQ (*it, 0) << "Element 2 (chunk 1, index 0)";
+}
+
+TEST (ChunkedVectorResize, ResizeWholeChunkPlus1) {
+    cvector_int cv;
+    // Resize from 0 to 5 elements:
+    //     [ 0, 0 ] -> [ 0, 0 ] -> [ 0, _ ]
+    cv.resize (5U);
+    EXPECT_EQ (cv.size (), 5U);
+    EXPECT_EQ (cv.capacity (), 6U);
+
+    cvector_int::const_iterator it = cv.begin ();
+    EXPECT_EQ (*it, 0) << "Element 0 (chunk 0, index 0)";
+    std::advance (it, 1);
+    EXPECT_EQ (*it, 0) << "Element 1 (chunk 0, index 1)";
+    std::advance (it, 1);
+    EXPECT_EQ (*it, 0) << "Element 2 (chunk 1, index 0)";
+    std::advance (it, 1);
+    EXPECT_EQ (*it, 0) << "Element 3 (chunk 1, index 1)";
+    std::advance (it, 1);
+    EXPECT_EQ (*it, 0) << "Element 4 (chunk 1, index 1)";
+}
+
+TEST (ChunkedVectorResize, TwoElementsDownToOne) {
+    cvector_int cv;
+    cv.emplace_back (17);
+    cv.emplace_back (19);
+    // Before: [ 17, 19 ]
+    // After: [ 17, _ ]
+    cv.resize (1U);
+    EXPECT_EQ (cv.size (), 1U);
+    EXPECT_EQ (cv.capacity (), 2U);
+
+    cvector_int::const_iterator it = cv.begin ();
+    EXPECT_EQ (*it, 17) << "Element 0 (chunk 0, index 0)";
+}
+
+TEST (ChunkedVectorResize, TwoElementsDownToZero) {
+    cvector_int cv;
+    cv.emplace_back (17);
+    cv.emplace_back (19);
+    // Before: [ 17, 19 ]
+    // After: [ _, _ ]
+    cv.resize (0U);
+    EXPECT_EQ (cv.size (), 0U);
+    EXPECT_EQ (cv.capacity (), 2U) << "There is always at least one chunk";
+}
+
+TEST (ChunkedVectorResize, FiveElementsDownToOne) {
+    cvector_int cv;
+    cv.emplace_back (17);
+    cv.emplace_back (19);
+    cv.emplace_back (23);
+    cv.emplace_back (29);
+    cv.emplace_back (31);
+    // Before: [ 17, 19 ] -> [ 23, 29 ] -> [ 31, _ ]
+    // After: [ 17, _ ]
+    cv.resize (1U);
+    EXPECT_EQ (cv.size (), 1U);
+    EXPECT_EQ (cv.capacity (), 2U);
+
+    cvector_int::const_iterator it = cv.begin ();
+    EXPECT_EQ (*it, 17) << "Element 0 (chunk 0, index 0)";
 }


### PR DESCRIPTION
This PR adds a resize() method to the `chunked_vector<>` (CV) container.

Some background: CV is a [sequence-container](https://en.cppreference.com/w/cpp/named_req/SequenceContainer) [<sup>[1]</sup>](#footnote1) that is optimized for fast insertion at the end (i.e. emplace/push_back). It stores its members as an ordered list of “chunks” each of which has storage for a number of objects. This number is a compile-time constant and is usually reasonably large and chosen so that the memory required is a multiple of the VM page size. Appending is performed in amortized constant time where we either bump a pointer in an existing chunk or allocate a new one. Unlike `std::vector<>` or `llvm::SmallVector<>`, no moving or copying occurs and only the past-the-end iterator is invalidated.

pstore makes relatively little use of this container at the moment (`hamt_map<>` uses it to hold modified branch nodes before they are flushed during transaction commit). On the other hand, rld has several occurrences of the container (e.g. symbol table entries and the individual “contributions” attached to output sections during layout) and I want to add another.

I recently realized that rld had a bug in its handling of the case of a fragment shared by multiple definitions. If such a fragment has one or more external fixups which reference definitions with internal linkage then the linker must ensure that those fixups are resolved to the correct local definition.

Previously, symbol resolution was performed on each section’s fixups at most once. It must however be performed each time that a definition is added to the symbol table to ensure that external fixups always resolve to the correct internal definition [<sup>[2]</sup>](#footnote2). To fix this problem, I am now attaching the collection of referenced symbols to the each definition’s symbol-table entry. Previously  “shadow memory” associated with the fragment was used for this purpose. Sadly, this invalidates the diagram [here](https://github.com/SNSystems/llvm-project-prepo/wiki/%5Brld%5D-Linker-Structure#structural-view) which must now be updated.

The “collection of referenced symbols” is a contiguous sequence of `rld::Symbol *` (this is important for the performance of the code that applies the fixups during the linker’s copy phase). My intention is to use one CV per worker thread to store the symbol-resolution output without needing to add locks.For each section processed, the code will resize the container to guarantee a contiguous block of entries sufficient for that section’s external fixups [<sup>[3]</sup>](#footnote3).

All of this means that we need an implementation of resize() for CV.

---

<a name="footnote1"><sup>[1]</sup></a> Well, mostly. It doesn’t implement all of the required methods such as insert() and erase(). These will be added if and when they are needed.

<a name="footnote2"><sup>[2]</sup></a> Of course, this is only necessary if the fragment _does_ reference definitions with internal linkage. If not, then a single resolution pass is sufficient for all cases. I can optimize for this, likely quite common, situation.

<a name="footnote3"><sup>[3]</sup></a> For the, hopefully rare, case where the number of fixups exceeds the CV’s chunk-size, I’ll maintain a separate collection of `std::vector<>`.