### PR TITLE
Separate section_sparray from fragment

### DIFF
--- a/include/pstore/adt/sparse_array.hpp
+++ b/include/pstore/adt/sparse_array.hpp
@@ -195,12 +195,12 @@ namespace pstore {
         sparse_array (IteratorIdx first_index, IteratorIdx last_index);
 
         sparse_array (sparse_array const &) = delete;
-        sparse_array (sparse_array &&) = delete;
+        sparse_array (sparse_array &&) noexcept = delete;
 
-        ~sparse_array ();
+        ~sparse_array () noexcept;
 
         sparse_array & operator= (sparse_array const &) = delete;
-        sparse_array & operator= (sparse_array &&) = delete;
+        sparse_array & operator= (sparse_array &&) noexcept = delete;
 
 
         /// Constructs a sparse_array<> instance where the indices are extracted from an iterator
@@ -510,7 +510,7 @@ namespace pstore {
     // (dtor)
     // ~~~~~~
     template <typename ValueType, typename BitmapType>
-    sparse_array<ValueType, BitmapType>::~sparse_array () {
+    sparse_array<ValueType, BitmapType>::~sparse_array () noexcept {
         auto const elements = size ();
         if (elements > 1) {
             for (auto it = &elements_[1], end = &elements_[0] + elements; it != end; ++it) {

--- a/include/pstore/mcrepo/fragment.hpp
+++ b/include/pstore/mcrepo/fragment.hpp
@@ -149,7 +149,7 @@ namespace pstore {
             /// \param kind  The section kind to check.
             /// \returns Returns true if the fragment contains a section of the kind given by
             ///   \p kind, false otherwise.
-            constexpr bool has_section (section_kind const kind) const noexcept {
+            bool has_section (section_kind const kind) const noexcept {
                 return arr_.has_index (kind);
             }
 

--- a/include/pstore/mcrepo/fragment.hpp
+++ b/include/pstore/mcrepo/fragment.hpp
@@ -16,10 +16,10 @@
 #ifndef PSTORE_MCREPO_FRAGMENT_HPP
 #define PSTORE_MCREPO_FRAGMENT_HPP
 
-#include "pstore/adt/sparse_array.hpp"
 #include "pstore/mcrepo/bss_section.hpp"
 #include "pstore/mcrepo/debug_line_section.hpp"
 #include "pstore/mcrepo/linked_definitions_section.hpp"
+#include "pstore/mcrepo/section_sparray.hpp"
 #include "pstore/support/pointee_adaptor.hpp"
 
 namespace pstore {
@@ -106,7 +106,9 @@ namespace pstore {
         //*              |___/                    *
         class fragment {
         public:
-            using member_array = sparse_array<std::uint64_t>;
+            // TODO: 32-bits would be plenty for an intra-fragment offset.
+            using member_array = section_sparray<std::uint64_t>;
+            using const_iterator = member_array::indices::const_iterator;
 
             /// Prepares an instance of a fragment with the collection of sections defined by the
             /// iterator range [first, last).
@@ -147,9 +149,8 @@ namespace pstore {
             /// \param kind  The section kind to check.
             /// \returns Returns true if the fragment contains a section of the kind given by
             ///   \p kind, false otherwise.
-            bool has_section (section_kind const kind) const noexcept {
-                return arr_.has_index (
-                    static_cast<std::underlying_type<section_kind>::type> (kind));
+            constexpr bool has_section (section_kind const kind) const noexcept {
+                return arr_.has_index (kind);
             }
 
             /// \name Section Access
@@ -188,50 +189,9 @@ namespace pstore {
             /// Returns the array of section offsets.
             member_array const & members () const noexcept { return arr_; }
 
-            /// An iterator which makes the process of iterating over the sections within
-            /// a loaded fragment quite straightforward.
-            class const_iterator {
-                using wrapped_iterator = member_array::indices::const_iterator;
 
-            public:
-                using iterator_category = std::forward_iterator_tag;
-                using value_type = section_kind;
-                using difference_type = wrapped_iterator::difference_type;
-                using pointer = value_type const *;
-                using reference = value_type const &;
-
-                constexpr const_iterator (section_kind const kind,
-                                          wrapped_iterator const & it) noexcept
-                        : section_kind_{kind}
-                        , it_{it} {}
-                constexpr explicit const_iterator (wrapped_iterator const & it) noexcept
-                        : const_iterator (static_cast<section_kind> (*it), it) {
-                    PSTORE_ASSERT (*it < static_cast<std::uint64_t> (section_kind::last));
-                }
-
-                bool operator== (const_iterator const & rhs) const noexcept {
-                    return it_ == rhs.it_;
-                }
-                bool operator!= (const_iterator const & rhs) const noexcept {
-                    return !operator== (rhs);
-                }
-
-                reference operator* () const noexcept { return section_kind_; }
-                pointer operator-> () const noexcept { return &section_kind_; }
-                const_iterator & operator++ () noexcept;
-                const_iterator operator++ (int) noexcept;
-
-            private:
-                section_kind section_kind_;
-                wrapped_iterator it_;
-            };
-
-            const_iterator begin () const noexcept {
-                return const_iterator{arr_.get_indices ().begin ()};
-            }
-            const_iterator end () const noexcept {
-                return const_iterator{section_kind::last, arr_.get_indices ().end ()};
-            }
+            const_iterator begin () const noexcept { return arr_.get_indices ().begin (); }
+            const_iterator end () const noexcept { return arr_.get_indices ().end (); }
 
             /// Returns the number of bytes of storage that are required for a fragment containing
             /// the sections defined by [first, last).
@@ -250,7 +210,7 @@ namespace pstore {
         private:
             template <typename IteratorIdx>
             constexpr fragment (IteratorIdx const first_index, IteratorIdx const last_index)
-                    : arr_ (first_index, last_index) {
+                    : arr_{first_index, last_index} {
 
                 // Verify that the structure layout is the same regardless of the compiler and
                 // target platform.
@@ -260,14 +220,6 @@ namespace pstore {
                 PSTORE_STATIC_ASSERT (offsetof (fragment, padding1_) == 8);
                 PSTORE_STATIC_ASSERT (offsetof (fragment, arr_) == 16);
                 padding1_ = 0; // assignment to silence an "unused" warning from clang.
-
-                static_assert (
-                    std::numeric_limits<member_array::bitmap_type>::radix == 2,
-                    "expect numeric radix to be 2 (so that 'digits' is the number of bits)");
-                using utype = std::underlying_type<section_kind>::type;
-                static_assert (static_cast<utype> (section_kind::last) <=
-                                   std::numeric_limits<member_array::bitmap_type>::digits,
-                               "section_kind does not fit in the member sparse array");
             }
 
             /// Returns pointer to an individual fragment instance given a function which can yield
@@ -323,8 +275,7 @@ namespace pstore {
                           Fragment, typename enum_to_section<Key>::type>::type>
             static ResultType & at_impl (Fragment && f) noexcept {
                 PSTORE_ASSERT (f.has_section (Key));
-                using utype = std::underlying_type<section_kind>::type;
-                return f.template offset_to_instance<ResultType> (f.arr_[static_cast<utype> (Key)]);
+                return f.template offset_to_instance<ResultType> (f.arr_[Key]);
             }
 
             /// The implementation of atp<>() (used by the const and non-const flavors).
@@ -399,10 +350,9 @@ case section_kind::k: name = #k; break;
             // Copy the contents of each of the segments to the fragment.
             std::for_each (
                 first, last, [&out, &fragment_ptr] (section_creation_dispatcher const & c) {
-                    auto const index = static_cast<unsigned> (c.kind ());
                     out = reinterpret_cast<std::uint8_t *> (c.aligned (out));
-                    fragment_ptr->arr_[index] = reinterpret_cast<std::uintptr_t> (out) -
-                                                reinterpret_cast<std::uintptr_t> (fragment_ptr);
+                    fragment_ptr->arr_[c.kind ()] = reinterpret_cast<std::uintptr_t> (out) -
+                                                    reinterpret_cast<std::uintptr_t> (fragment_ptr);
                     out = c.write (out);
                 });
 #ifndef NDEBUG
@@ -435,7 +385,7 @@ case section_kind::k: name = #k; break;
         }
 
 
-        // load_impl
+        // load impl
         // ~~~~~~~~~
         template <typename ReturnType, typename GetOp>
         auto fragment::load_impl (extent<fragment> const & fext, GetOp get) -> ReturnType {
@@ -461,7 +411,7 @@ case section_kind::k: name = #k; break;
         }
 
 
-        // offset_to_instance
+        // offset to instance
         // ~~~~~~~~~~~~~~~~~~
         // This is the implementation used by both const and non-const flavors of
         // offset_to_instance().
@@ -473,7 +423,7 @@ case section_kind::k: name = #k; break;
                 offset);
         }
 
-        // check_range_is_sorted
+        // check range is sorted
         // ~~~~~~~~~~~~~~~~~~~~~
         template <typename Iterator>
         void fragment::check_range_is_sorted (Iterator first, Iterator last) {
@@ -514,19 +464,6 @@ case section_kind::k: name = #k; break;
             return size_bytes;
         }
 
-
-        // fragment::const_iterator
-        // ~~~~~~~~~~~~~~~~~~~~~~~~
-        inline fragment::const_iterator & fragment::const_iterator::operator++ () noexcept {
-            ++it_;
-            section_kind_ = static_cast<section_kind> (*it_);
-            return *this;
-        }
-        inline fragment::const_iterator fragment::const_iterator::operator++ (int) noexcept {
-            auto const prev = *this;
-            ++*this;
-            return prev;
-        }
 
         /// Returns the alignment of the given section type in the given fragment.
         unsigned section_align (fragment const & fragment, section_kind kind);

--- a/include/pstore/mcrepo/section_sparray.hpp
+++ b/include/pstore/mcrepo/section_sparray.hpp
@@ -1,0 +1,261 @@
+//===- include/pstore/mcrepo/section_sparray.hpp ----------*- mode: C++ -*-===//
+//*                _   _                                                     *
+//*  ___  ___  ___| |_(_) ___  _ __    ___ _ __   __ _ _ __ _ __ __ _ _   _  *
+//* / __|/ _ \/ __| __| |/ _ \| '_ \  / __| '_ \ / _` | '__| '__/ _` | | | | *
+//* \__ \  __/ (__| |_| | (_) | | | | \__ \ |_) | (_| | |  | | | (_| | |_| | *
+//* |___/\___|\___|\__|_|\___/|_| |_| |___/ .__/ \__,_|_|  |_|  \__,_|\__, | *
+//*                                       |_|                         |___/  *
+//===----------------------------------------------------------------------===//
+//
+// Part of the pstore project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://github.com/SNSystems/pstore/blob/master/LICENSE.txt for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+/// \file section_sparray.hpp
+/// \brief A wrapper for sparse_array<> which accepts indices of type section_kind.
+
+#ifndef PSTORE_MCREPO_SECTION_SPARRAY_HPP
+#define PSTORE_MCREPO_SECTION_SPARRAY_HPP
+
+#include <iterator>
+#include <limits>
+
+#include "pstore/adt/sparse_array.hpp"
+#include "pstore/mcrepo/section.hpp"
+
+namespace pstore {
+    namespace repo {
+
+        namespace details {
+
+            template <typename CastToType, typename BaseIterator>
+            class cast_iterator {
+            public:
+                using iterator_category =
+                    typename std::iterator_traits<BaseIterator>::iterator_category;
+                using value_type = CastToType;
+                using difference_type =
+                    typename std::iterator_traits<BaseIterator>::difference_type;
+                using pointer = value_type const *;
+                using reference = value_type const &;
+
+                constexpr explicit cast_iterator (BaseIterator it);
+                constexpr bool operator== (cast_iterator const & rhs) const;
+                constexpr bool operator!= (cast_iterator const & rhs) const;
+                constexpr value_type operator* () const;
+                cast_iterator & operator++ ();  // ++prefix
+                cast_iterator operator++ (int); // postfix++
+                cast_iterator & operator-- ();  // --prefix
+                cast_iterator operator-- (int); // postfix--
+                cast_iterator operator+ (unsigned x) const { return cast_iterator{it_ + x}; }
+                cast_iterator operator- (unsigned x) const { return cast_iterator{it_ - x}; }
+
+            private:
+                BaseIterator it_;
+            };
+            template <typename CastToType, typename BaseIterator>
+            constexpr cast_iterator<CastToType, BaseIterator>::cast_iterator (BaseIterator it)
+                    : it_{it} {}
+            template <typename CastToType, typename BaseIterator>
+            constexpr bool
+            cast_iterator<CastToType, BaseIterator>::operator== (cast_iterator const & rhs) const {
+                return it_ == rhs.it_;
+            }
+            template <typename CastToType, typename BaseIterator>
+            constexpr bool
+            cast_iterator<CastToType, BaseIterator>::operator!= (cast_iterator const & rhs) const {
+                return !operator== (rhs);
+            }
+            template <typename CastToType, typename BaseIterator>
+            constexpr auto cast_iterator<CastToType, BaseIterator>::operator* () const
+                -> value_type {
+                return static_cast<CastToType> (*it_);
+            }
+            template <typename CastToType, typename BaseIterator>
+            inline auto cast_iterator<CastToType, BaseIterator>::operator++ ()
+                -> cast_iterator & { // ++prefix
+                ++it_;
+                return *this;
+            }
+            template <typename CastToType, typename BaseIterator>
+            inline auto cast_iterator<CastToType, BaseIterator>::operator++ (int)
+                -> cast_iterator { // prefix++
+                auto prev = *this;
+                ++(*this);
+                return prev;
+            }
+            template <typename CastToType, typename BaseIterator>
+            inline auto cast_iterator<CastToType, BaseIterator>::operator-- ()
+                -> cast_iterator & { // ++prefix
+                --it_;
+                return *this;
+            }
+            template <typename CastToType, typename BaseIterator>
+            inline auto cast_iterator<CastToType, BaseIterator>::operator-- (int)
+                -> cast_iterator { // prefix++
+                auto prev = *this;
+                --(*this);
+                return prev;
+            }
+
+        } // end namespace details
+
+        /// A wrapper for the sparse_array<> type which is specialized for indices of type
+        /// section_kind.
+        template <typename T>
+        class section_sparray {
+        private:
+            using index_type = std::underlying_type_t<section_kind>;
+            static_assert (std::is_unsigned<index_type>::value,
+                           "section-kind underlying type should be unsigned");
+
+            /// Returns the maximum section-kind value.
+            static constexpr auto max_section_kind () noexcept
+                -> std::underlying_type_t<section_kind> {
+                return static_cast<std::underlying_type_t<section_kind>> (section_kind::last);
+            }
+
+            /// Returns true if the value_type of Iterator is section_kind.
+            template <typename Iterator>
+            static constexpr bool is_section_kind_iterator () {
+                return std::is_same<typename std::remove_cv<
+                                        typename std::iterator_traits<Iterator>::value_type>::type,
+                                    section_kind>::value;
+            }
+
+            using array_type = sparse_array<T, sparray_bitmap_t<max_section_kind ()>>;
+
+        public:
+            using value_type = typename array_type::value_type;
+            using size_type = typename array_type::size_type;
+
+            /// Constructs a sparse array whose available indices are defined by the iterator range
+            /// from [first,last) and whose corresponding values are default constructed.
+            template <typename IndexIterator, typename = typename std::enable_if_t<
+                                                  is_section_kind_iterator<IndexIterator> ()>>
+            constexpr section_sparray (IndexIterator first, IndexIterator last);
+
+            /// \name Element access
+            ///@{
+            constexpr value_type & operator[] (section_kind k) noexcept;
+            constexpr value_type const & operator[] (section_kind k) const noexcept;
+
+            /// Returns the first section-kind index in the container. This is the smallest value
+            /// that can be passed to operator[].
+            constexpr value_type front () const noexcept;
+            /// Returns the last section-kind index in the container. This is the largest value that
+            /// can be passed to operator[].
+            constexpr value_type back () const noexcept;
+            ///@}
+
+
+            /// Returns the number of bytes of storage that are required for an instance of
+            /// section_sparray<T> where \p members is the number of available section-kinds.
+            static constexpr std::size_t size_bytes (std::size_t members) noexcept;
+            /// Returns the number of bytes of storage that are being used by this array instance.
+            constexpr std::size_t size_bytes () const {
+                return section_sparray<T>::size_bytes (this->size ());
+            }
+
+
+            /// \name Capacity
+            ///@{
+            constexpr bool empty () const noexcept { return sa_.empty (); }
+            constexpr size_type size () const noexcept { return sa_.size (); }
+
+            /// Returns the maximum number of indices that could be contained by an instance of this
+            /// sparse_array type.
+            static constexpr size_type max_size () noexcept { return array_type::max_size (); }
+
+            /// Returns true if the sparse array has an index 'pos'.
+            constexpr bool has_index (section_kind pos) const noexcept {
+                return sa_.has_index (static_cast<index_type> (pos));
+            }
+            ///@}
+
+            /// A container which can be used to access and iterate over the available index values
+            /// in the sparse array.
+            class indices {
+            public:
+                using iterator =
+                    details::cast_iterator<section_kind,
+                                           typename array_type::indices::const_iterator>;
+                using const_iterator = iterator;
+
+                constexpr explicit indices (typename array_type::indices const & i) noexcept
+                        : i_{i} {}
+                constexpr iterator begin () const noexcept { return iterator{i_.begin ()}; }
+                constexpr iterator end () const noexcept { return iterator{i_.end ()}; }
+                constexpr bool empty () const noexcept { return i_.empty (); }
+
+                section_kind front () const noexcept {
+                    return static_cast<section_kind> (i_.front ());
+                }
+                section_kind back () const noexcept {
+                    return static_cast<section_kind> (i_.back ());
+                }
+
+            private:
+                typename array_type::indices const i_;
+            };
+
+            indices get_indices () const noexcept { return indices{sa_.get_indices ()}; }
+
+        private:
+            array_type sa_;
+        };
+
+        // (ctor)
+        // ~~~~~~
+        template <typename T>
+        template <typename IndexIterator, typename>
+        constexpr section_sparray<T>::section_sparray (IndexIterator first, IndexIterator last)
+                : sa_{details::cast_iterator<index_type, IndexIterator>{first},
+                      details::cast_iterator<index_type, IndexIterator>{last}} {
+
+            static_assert (
+                std::numeric_limits<typename array_type::bitmap_type>::radix == 2,
+                "expected numeric radix to be 2 (so that 'digits' is the number of bits)");
+            static_assert (static_cast<index_type> (section_kind::last) <=
+                               std::numeric_limits<typename array_type::bitmap_type>::digits,
+                           "section_kind does not fit in the member sparse array");
+        }
+
+        // front
+        // ~~~~~
+        template <typename T>
+        constexpr auto section_sparray<T>::front () const noexcept -> value_type {
+            return static_cast<value_type> (sa_.front ());
+        }
+        // back
+        // ~~~~
+        template <typename T>
+        constexpr auto section_sparray<T>::back () const noexcept -> value_type {
+            return static_cast<value_type> (sa_.back ());
+        }
+
+        // operator[]
+        // ~~~~~~~~~~
+        template <typename T>
+        constexpr auto section_sparray<T>::operator[] (section_kind k) noexcept -> value_type & {
+            return sa_[static_cast<index_type> (k)];
+        }
+        template <typename T>
+        constexpr auto section_sparray<T>::operator[] (section_kind k) const noexcept
+            -> value_type const & {
+            return sa_[static_cast<index_type> (k)];
+        }
+
+        // size bytes
+        // ~~~~~~~~~~
+        template <typename T>
+        constexpr std::size_t section_sparray<T>::size_bytes (std::size_t const members) noexcept {
+            return array_type::size_bytes (members);
+        }
+
+    } // end namespace repo
+} // end namespace pstore
+
+#endif // PSTORE_MCREPO_SECTION_SPARRAY_HPP

--- a/include/pstore/mcrepo/section_sparray.hpp
+++ b/include/pstore/mcrepo/section_sparray.hpp
@@ -130,6 +130,10 @@ namespace pstore {
         public:
             using value_type = typename array_type::value_type;
             using size_type = typename array_type::size_type;
+            using iterator = typename array_type::iterator;
+            using const_iterator = typename array_type::const_iterator;
+            using reference = value_type &;
+            using const_reference = value_type const &;
 
             /// Constructs a sparse array whose available indices are defined by the iterator range
             /// from [first,last) and whose corresponding values are default constructed.
@@ -142,12 +146,14 @@ namespace pstore {
             constexpr value_type & operator[] (section_kind k) noexcept;
             constexpr value_type const & operator[] (section_kind k) const noexcept;
 
-            /// Returns the first section-kind index in the container. This is the smallest value
-            /// that can be passed to operator[].
-            constexpr value_type front () const noexcept;
-            /// Returns the last section-kind index in the container. This is the largest value that
-            /// can be passed to operator[].
-            constexpr value_type back () const noexcept;
+            /// Returns the value associated with the first section-kind index in the container.
+            constexpr reference front () noexcept;
+            /// Returns the value associated with the first section-kind index in the container.
+            constexpr const_reference front () const noexcept;
+            /// Returns the value associated with the last section-kind index in the container.
+            constexpr reference back () noexcept;
+            /// Returns the value associated with the last section-kind index in the container.
+            constexpr const_reference back () const noexcept;
             ///@}
 
 
@@ -159,17 +165,32 @@ namespace pstore {
                 return section_sparray<T>::size_bytes (this->size ());
             }
 
+            /// \name Iterators
+            ///@{
+
+            /// Returns an iterator to the beginning of the container.
+            iterator begin () { return sa_.begin (); }
+            const_iterator begin () const { return sa_.begin (); }
+            const_iterator cbegin () const { return sa_.cbegin (); }
+
+            /// Returns an iterator to the end of the container.
+            iterator end () { return sa_.end (); }
+            const_iterator end () const { return sa_.end (); }
+            const_iterator cend () const { return sa_.cend (); }
+
+            ///@}
+
 
             /// \name Capacity
             ///@{
             constexpr bool empty () const noexcept { return sa_.empty (); }
             constexpr size_type size () const noexcept { return sa_.size (); }
 
-            /// Returns the maximum number of indices that could be contained by an instance of this
-            /// sparse_array type.
-            static constexpr size_type max_size () noexcept { return array_type::max_size (); }
-
-            /// Returns true if the sparse array has an index 'pos'.
+            /// Returns true if the sparse array has an index \p pos.
+            ///
+            /// \param pos  The section kind to be tested.
+            /// \returns True if the sparse array has an index for the \p pos section; false
+            ///   otherwise.
             constexpr bool has_index (section_kind pos) const noexcept {
                 return sa_.has_index (static_cast<index_type> (pos));
             }
@@ -226,14 +247,22 @@ namespace pstore {
         // front
         // ~~~~~
         template <typename T>
-        constexpr auto section_sparray<T>::front () const noexcept -> value_type {
-            return static_cast<value_type> (sa_.front ());
+        constexpr auto section_sparray<T>::front () noexcept -> reference {
+            return sa_.front ();
+        }
+        template <typename T>
+        constexpr auto section_sparray<T>::front () const noexcept -> const_reference {
+            return sa_.front ();
         }
         // back
         // ~~~~
         template <typename T>
-        constexpr auto section_sparray<T>::back () const noexcept -> value_type {
-            return static_cast<value_type> (sa_.back ());
+        constexpr auto section_sparray<T>::back () noexcept -> reference {
+            return sa_.back ();
+        }
+        template <typename T>
+        constexpr auto section_sparray<T>::back () const noexcept -> const_reference {
+            return sa_.back ();
         }
 
         // operator[]

--- a/include/pstore/mcrepo/section_sparray.hpp
+++ b/include/pstore/mcrepo/section_sparray.hpp
@@ -44,7 +44,7 @@ namespace pstore {
                 constexpr explicit cast_iterator (BaseIterator it);
                 constexpr bool operator== (cast_iterator const & rhs) const;
                 constexpr bool operator!= (cast_iterator const & rhs) const;
-                constexpr value_type operator* () const;
+                constexpr reference operator* () const;
                 cast_iterator & operator++ ();  // ++prefix
                 cast_iterator operator++ (int); // postfix++
                 cast_iterator & operator-- ();  // --prefix
@@ -54,6 +54,7 @@ namespace pstore {
 
             private:
                 BaseIterator it_;
+                mutable value_type value_;
             };
             template <typename CastToType, typename BaseIterator>
             constexpr cast_iterator<CastToType, BaseIterator>::cast_iterator (BaseIterator it)
@@ -70,8 +71,8 @@ namespace pstore {
             }
             template <typename CastToType, typename BaseIterator>
             constexpr auto cast_iterator<CastToType, BaseIterator>::operator* () const
-                -> value_type {
-                return static_cast<CastToType> (*it_);
+                -> reference {
+                return value_ = static_cast<CastToType> (*it_);
             }
             template <typename CastToType, typename BaseIterator>
             inline auto cast_iterator<CastToType, BaseIterator>::operator++ ()

--- a/lib/mcrepo/CMakeLists.txt
+++ b/lib/mcrepo/CMakeLists.txt
@@ -36,5 +36,6 @@ add_pstore_library (
         generic_section.hpp
         repo_error.hpp
         section.hpp
+        section_sparray.hpp
 )
 target_link_libraries (pstore-mcrepo PUBLIC pstore-adt pstore-core)

--- a/lib/mcrepo/fragment.cpp
+++ b/lib/mcrepo/fragment.cpp
@@ -123,15 +123,14 @@ bool fragment::fragment_appears_valid (fragment const & f, pstore::extent<fragme
 #endif // PSTORE_SIGNATURE_CHECKS_ENABLED
 
     auto const indices = f.arr_.get_indices ();
-    using utype = std::underlying_type<section_kind>::type;
-    if (indices.empty () || indices.back () >= static_cast<utype> (section_kind::last)) {
+    if (indices.empty () || indices.back () >= section_kind::last) {
         return false;
     }
 
     std::uint64_t offset = sizeof (fragment);
-    auto const index_end = std::end (indices);
-    for (auto index_it = std::begin (indices); index_it != index_end; ++index_it) {
-        std::size_t const index = *index_it;
+    for (auto index_it = std::begin (indices), index_end = std::end (indices);
+         index_it != index_end; ++index_it) {
+        section_kind const index = *index_it;
 
         auto const this_offset = f.arr_[index];
         auto const next_offset = (index == indices.back ()) ? fext.size : f.arr_[*(index_it + 1)];

--- a/unittests/adt/test_sparse_array.cpp
+++ b/unittests/adt/test_sparse_array.cpp
@@ -253,17 +253,18 @@ TYPED_TEST (SparseArray, Indices) {
 }
 
 TYPED_TEST (SparseArray, SizeBytesAgree) {
-    std::vector<std::pair<int, int>> empty;
-    EXPECT_EQ ((sparse_array<int, TypeParam>::make_unique (std::begin (empty), std::end (empty))
-                    ->size_bytes ()),
-               (sparse_array<int, TypeParam>::size_bytes (0)));
+    std::vector<std::pair<unsigned, unsigned>> empty;
+    EXPECT_EQ (
+        (sparse_array<unsigned, TypeParam>::make_unique (std::begin (empty), std::end (empty))
+             ->size_bytes ()),
+        (sparse_array<unsigned, TypeParam>::size_bytes (0)));
 
-    EXPECT_EQ ((sparse_array<int, TypeParam>::make_unique ({0})->size_bytes ()),
-               (sparse_array<int, TypeParam>::size_bytes (1)));
-    EXPECT_EQ ((sparse_array<int, TypeParam>::make_unique ({1, 3})->size_bytes ()),
-               (sparse_array<int, TypeParam>::size_bytes (2)));
-    EXPECT_EQ ((sparse_array<int, TypeParam>::make_unique ({1, 3, 5, 7, 11})->size_bytes ()),
-               (sparse_array<int, TypeParam>::size_bytes (5)));
+    EXPECT_EQ ((sparse_array<unsigned, TypeParam>::make_unique ({0})->size_bytes ()),
+               (sparse_array<unsigned, TypeParam>::size_bytes (1)));
+    EXPECT_EQ ((sparse_array<unsigned, TypeParam>::make_unique ({1, 3})->size_bytes ()),
+               (sparse_array<unsigned, TypeParam>::size_bytes (2)));
+    EXPECT_EQ ((sparse_array<unsigned, TypeParam>::make_unique ({1, 3, 5, 7, 11})->size_bytes ()),
+               (sparse_array<unsigned, TypeParam>::size_bytes (5)));
 }
 
 TYPED_TEST (SparseArray, FrontAndBack) {

--- a/unittests/mcrepo/CMakeLists.txt
+++ b/unittests/mcrepo/CMakeLists.txt
@@ -18,6 +18,7 @@ add_pstore_unit_test (pstore-mcrepo-unit-tests
     test_compilation.cpp
     test_debug_line_section.cpp
     test_fragment.cpp
+    test_section_sparray.cpp
     transaction.cpp
     transaction.hpp
 )

--- a/unittests/mcrepo/test_fragment.cpp
+++ b/unittests/mcrepo/test_fragment.cpp
@@ -108,9 +108,9 @@ TEST_F (FragmentTest, MakeReadOnlySection) {
                reinterpret_cast<std::uint8_t const *> (extent.addr.absolute ()));
     auto f = reinterpret_cast<fragment const *> (transaction_.get_storage ().begin ()->first);
 
-    std::vector<std::size_t> const expected{static_cast<std::size_t> (section_kind::read_only)};
-    auto indices = f->members ().get_indices ();
-    std::vector<std::size_t> const actual (std::begin (indices), std::end (indices));
+    std::vector<section_kind> const expected{section_kind::read_only};
+    auto const indices = f->members ().get_indices ();
+    std::vector<section_kind> const actual{std::begin (indices), std::end (indices)};
     EXPECT_THAT (actual, ::testing::ContainerEq (expected));
 
     generic_section const & s = f->at<section_kind::read_only> ();
@@ -164,9 +164,9 @@ TEST_F (FragmentTest, MakeTextSectionWithFixups) {
     auto f = reinterpret_cast<fragment const *> (transaction_.get_storage ().begin ()->first);
 
 
-    std::vector<std::size_t> const expected{static_cast<std::size_t> (section_kind::text)};
-    auto indices = f->members ().get_indices ();
-    std::vector<std::size_t> actual (std::begin (indices), std::end (indices));
+    std::vector<section_kind> const expected{section_kind::text};
+    auto const indices = f->members ().get_indices ();
+    std::vector<section_kind> actual{std::begin (indices), std::end (indices)};
     EXPECT_THAT (actual, ::testing::ContainerEq (expected));
 
     generic_section const & s = f->at<section_kind::text> ();
@@ -267,10 +267,9 @@ TEST_F (FragmentTest, TwoSections) {
     build_two_sections (transaction_);
 
     auto f = reinterpret_cast<fragment const *> (transaction_.get_storage ().begin ()->first);
-    std::vector<std::size_t> const expected{static_cast<std::size_t> (section_kind::read_only),
-                                            static_cast<std::size_t> (section_kind::thread_data)};
+    std::vector<section_kind> const expected{section_kind::read_only, section_kind::thread_data};
     auto const indices = f->members ().get_indices ();
-    std::vector<std::size_t> const actual (std::begin (indices), std::end (indices));
+    std::vector<section_kind> const actual{std::begin (indices), std::end (indices)};
     EXPECT_THAT (actual, ::testing::ContainerEq (expected));
 
     generic_section const & rodata = f->at<section_kind::read_only> ();

--- a/unittests/mcrepo/test_section_sparray.cpp
+++ b/unittests/mcrepo/test_section_sparray.cpp
@@ -1,0 +1,110 @@
+//===- unittests/mcrepo/test_section_sparray.cpp --------------------------===//
+//*                _   _                                                     *
+//*  ___  ___  ___| |_(_) ___  _ __    ___ _ __   __ _ _ __ _ __ __ _ _   _  *
+//* / __|/ _ \/ __| __| |/ _ \| '_ \  / __| '_ \ / _` | '__| '__/ _` | | | | *
+//* \__ \  __/ (__| |_| | (_) | | | | \__ \ |_) | (_| | |  | | | (_| | |_| | *
+//* |___/\___|\___|\__|_|\___/|_| |_| |___/ .__/ \__,_|_|  |_|  \__,_|\__, | *
+//*                                       |_|                         |___/  *
+//===----------------------------------------------------------------------===//
+//
+// Part of the pstore project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://github.com/SNSystems/pstore/blob/master/LICENSE.txt for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include "pstore/mcrepo/section_sparray.hpp"
+
+#include <gmock/gmock.h>
+
+// A type built on unique_ptr<> but where placement new is used for allocation.
+namespace {
+
+    constexpr void nop_free (void *) noexcept {}
+
+    template <typename T>
+    using placement_unique_ptr = std::unique_ptr<T, decltype (&nop_free)>;
+
+    template <class T, class... Args>
+    std::enable_if_t<!std::is_array<T>::value, placement_unique_ptr<T>>
+    make_placement_unique_ptr (void * ptr, Args &&... args) {
+        return placement_unique_ptr<T>{new (ptr) T (std::forward<Args> (args)...), &nop_free};
+    }
+
+} // end anonymous namespace
+
+using namespace pstore::repo;
+
+TEST (SectionSpArray, FrontAndBack) {
+    std::vector<section_kind> const indices{section_kind::text, section_kind::data};
+    using sparray = section_sparray<int>;
+
+    std::vector<std::uint8_t> storage;
+    storage.resize (sparray::size_bytes (indices.size ()));
+
+    auto arr = make_placement_unique_ptr<sparray> (storage.data (), std::begin (indices),
+                                                   std::end (indices));
+    (*arr)[section_kind::text] = 17;
+    (*arr)[section_kind::data] = 23;
+    EXPECT_EQ (arr->front (), 17);
+    EXPECT_EQ (arr->back (), 23);
+}
+
+TEST (SectionSpArray, BeginEnd) {
+    std::vector<section_kind> const indices{section_kind::text, section_kind::data};
+    using sparray = section_sparray<int>;
+
+    std::vector<std::uint8_t> storage;
+    storage.resize (sparray::size_bytes (indices.size ()));
+
+    auto arr = make_placement_unique_ptr<sparray> (storage.data (), std::begin (indices),
+                                                   std::end (indices));
+    (*arr)[section_kind::text] = 17;
+    (*arr)[section_kind::data] = 23;
+    std::vector<int> c{arr->begin (), arr->end ()};
+    EXPECT_THAT (c, testing::ElementsAre (17, 23));
+}
+
+
+TEST (SectionSpArray, HasIndex) {
+    std::vector<section_kind> const indices{section_kind::text, section_kind::data};
+    using sparray = section_sparray<int>;
+
+    std::vector<std::uint8_t> storage;
+    storage.resize (sparray::size_bytes (indices.size ()));
+
+    auto arr = make_placement_unique_ptr<sparray> (storage.data (), std::begin (indices),
+                                                   std::end (indices));
+    EXPECT_FALSE (arr->empty ());
+    EXPECT_EQ (arr->size (), indices.size ());
+    EXPECT_TRUE (arr->has_index (section_kind::text));
+    EXPECT_TRUE (arr->has_index (section_kind::data));
+    EXPECT_FALSE (arr->has_index (section_kind::read_only));
+}
+
+TEST (SectionSpArray, SizeBytes) {
+    std::vector<section_kind> const indices{section_kind::text, section_kind::data};
+
+    using sparray = section_sparray<int>;
+    auto const size = sparray::size_bytes (indices.size ());
+
+    std::vector<std::uint8_t> storage;
+    storage.resize (size);
+
+    auto arr = make_placement_unique_ptr<sparray> (storage.data (), std::begin (indices),
+                                                   std::end (indices));
+    EXPECT_EQ (size, arr->size_bytes ());
+}
+
+TEST (SectionSpArray, IndicesBeginEnd) {
+    std::vector<section_kind> const indices{section_kind::text, section_kind::data};
+    using sparray = section_sparray<int>;
+
+    std::vector<std::uint8_t> storage;
+    storage.resize (sparray::size_bytes (indices.size ()));
+
+    auto arr = make_placement_unique_ptr<sparray> (storage.data (), std::begin (indices),
+                                                   std::end (indices));
+    std::vector<section_kind> c{arr->get_indices ().begin (), arr->get_indices ().end ()};
+    EXPECT_THAT (c, testing::ElementsAre (section_kind::text, section_kind::data));
+}


### PR DESCRIPTION
In rld, I'd like to be able to use sparse_array<> to efficiently store information about a fragment’s sections (see the [idx standalone experiment](https://github.com/paulhuggett/ifx) for details.) The pstore fragment type already has something very close to what I need. This PR refactors that code to move it to a new  section_sparray.hpp and to expand it a little to support rld’s use-case. 

Add some simple unit tests for the new code. Fortunately, although there’s a lot of C++ boilerplate noise, this is a wrapper for the existing sparse_array<> type which is reasonably well tested. Most of the `section_sparray<>` methods simply forward to the sparse_array<> implementation. This code gets some minor modernization (esp. adding constexpr and noexcept annotations).