### PR TITLE
Updated the condition of setting the USE_FALLBACK variable.

### DIFF
--- a/lib/os/thread_posix.cpp
+++ b/lib/os/thread_posix.cpp
@@ -58,13 +58,7 @@ namespace pstore {
 #        define PTHREAD_GETNAME_NP 1
 #    endif
 
-// FIXME: The current musl libc library includes pthread_setname_np() but not yet
-// pthread_getname_np(). Therefore, we use the fallback if either function is missing. We will
-// revisit when a version of musl supporting pthread_getname_np() is released. Once musl libc
-// supports both functions, we should change the code to use the fallback only if _both_ functions aren’t
-// supported. If there is a mismatch, we would like the compile to fail with a #error to indicate
-// that there may be something to fix with the platform support.
-#    if !defined(PTHREAD_SETNAME_NP) || !defined(PTHREAD_GETNAME_NP)
+#    if !defined(PTHREAD_SETNAME_NP) && !defined(PTHREAD_GETNAME_NP)
 #        define USE_FALLBACK 1
 #    endif
 


### PR DESCRIPTION
Since pthread_getname_np function is implemented in the upstream musl project, I have rebased our forked musl-prepo project with the upstream/master branch.

Therefore, I removed the FIXME comment and updated the condition of setting the USE_FALLBACK variable.