### PR TITLE
On import, check that internal fixups target valid sections.

### DIFF
--- a/include/pstore/exchange/import_error.hpp
+++ b/include/pstore/exchange/import_error.hpp
@@ -68,6 +68,7 @@ namespace pstore {
                 bad_uuid,
                 bad_visibility,
                 unknown_section_name,
+                internal_fixup_target_not_found,
                 index_out_of_range,
                 debug_line_header_digest_not_found,
                 number_too_large,

--- a/include/pstore/exchange/import_fragment.hpp
+++ b/include/pstore/exchange/import_fragment.hpp
@@ -114,6 +114,12 @@ namespace pstore {
                     return &contents_[static_cast<std::underlying_type<repo::section_kind>::type> (
                         kind)];
                 }
+
+                /// Validates the fragment \p f.
+                ///
+                /// \param f  The fragment to be validated.
+                /// \returns No error is the fragment was valid or an opporiate error code if the fragment was not legal.
+                std::error_code check_fragment (repo::fragment const & f);
             };
 
             //*   __                             _     _         _          *

--- a/lib/exchange/import_error.cpp
+++ b/lib/exchange/import_error.cpp
@@ -116,6 +116,9 @@ namespace pstore {
                 case error::index_out_of_range: result = "index out of range"; break;
                 case error::unknown_section_name: result = "unknown section name"; break;
 
+                case error::internal_fixup_target_not_found:
+                    result = "the target section of a fragment's internal fixup was not present";
+                    break;
                 case error::debug_line_header_digest_not_found:
                     result = "debug line header digest was not found";
                     break;

--- a/unittests/exchange/CMakeLists.txt
+++ b/unittests/exchange/CMakeLists.txt
@@ -22,6 +22,7 @@ add_pstore_unit_test (pstore-exchange-unit-tests
     test_compilation.cpp
     test_export_emit.cpp
     test_export_ostream.cpp
+    test_fragment.cpp
     test_generic_section.cpp
     test_linked_definitions_section.cpp
     test_paths.cpp

--- a/unittests/exchange/test_fragment.cpp
+++ b/unittests/exchange/test_fragment.cpp
@@ -1,0 +1,86 @@
+//===- unittests/exchange/test_fragment.cpp -------------------------------===//
+//*   __                                      _    *
+//*  / _|_ __ __ _  __ _ _ __ ___   ___ _ __ | |_  *
+//* | |_| '__/ _` |/ _` | '_ ` _ \ / _ \ '_ \| __| *
+//* |  _| | | (_| | (_| | | | | | |  __/ | | | |_  *
+//* |_| |_|  \__,_|\__, |_| |_| |_|\___|_| |_|\__| *
+//*                |___/                           *
+//===----------------------------------------------------------------------===//
+//
+// Part of the pstore project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://github.com/SNSystems/pstore/blob/master/LICENSE.txt for license
+// information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include <string>
+
+// 3rd party includes
+#include <gtest/gtest.h>
+
+// pstore includes
+#include "pstore/exchange/import_fragment.hpp"
+#include "pstore/json/json.hpp"
+
+// local includes
+#include "empty_store.hpp"
+
+using namespace std::literals::string_literals;
+
+namespace {
+
+    using transaction_lock = std::unique_lock<mock_mutex>;
+    using transaction = pstore::transaction<transaction_lock>;
+
+    template <typename ImportRule, typename... Args>
+    auto make_json_object_parser (pstore::database * const db, Args... args)
+        -> pstore::json::parser<pstore::exchange::import_ns::callbacks> {
+        using namespace pstore::exchange::import_ns;
+        return pstore::json::make_parser (
+            callbacks::make<object_rule<ImportRule, Args...>> (db, args...));
+    }
+
+    decltype (auto)
+    import_fragment_parser (transaction * const transaction,
+                            pstore::exchange::import_ns::string_mapping * const names,
+                            pstore::index::digest const * const digest) {
+        return make_json_object_parser<pstore::exchange::import_ns::fragment_sections> (
+            &transaction->db (), transaction, names, digest);
+    }
+
+    class ImportFragment : public testing::Test {
+    public:
+        ImportFragment ()
+                : import_db_{import_store_.file ()} {
+            import_db_.set_vacuum_mode (pstore::database::vacuum_mode::disabled);
+        }
+
+        InMemoryStore import_store_;
+        pstore::database import_db_;
+    };
+
+} // end anonymous namespace
+
+TEST_F (ImportFragment, BadInternalFixupTargetSection) {
+    using namespace pstore::exchange::import_ns;
+
+    // This fragment contains a text section only but it has an internal fixup that targets the
+    // data section. The fragment should be rejected.
+    auto const input = R"({
+        "text": {
+            "data":"",
+            "ifixups":[ { "section":"data", "type":1, "offset":0, "addend":0 } ]
+        }
+    })"s;
+
+    mock_mutex mutex;
+    auto transaction = begin (import_db_, transaction_lock{mutex});
+
+    constexpr pstore::index::digest fragment_digest{0x11111111, 0x11111111};
+    string_mapping imported_names;
+
+    auto parser = import_fragment_parser (&transaction, &imported_names, &fragment_digest);
+    parser.input (input).eof ();
+    EXPECT_TRUE (parser.has_error ());
+    EXPECT_EQ (parser.last_error (), make_error_code (error::internal_fixup_target_not_found));
+}


### PR DESCRIPTION
Resolves #100.

Once we have gathered all of the sections that are part of an imported fragment we now make a pass through the internal fixups to ensure that there are no references to sections that are not present in the fragment.