### PR TITLE
Fix a clang warning about unused PTHREAD_GETNAME_NP macro

### DIFF
--- a/lib/support/CMakeLists.txt
+++ b/lib/support/CMakeLists.txt
@@ -48,6 +48,7 @@ check_include_files ("sys/endian.h" PSTORE_HAVE_SYS_ENDIAN_H)
 check_include_files ("sys/syscall.h" PSTORE_HAVE_SYS_SYSCALL_H)
 check_include_files ("sys/time.h;sys/types.h;sys/posix_shm.h" PSTORE_HAVE_SYS_POSIX_SHM_H)
 check_include_files ("syslog.h" PSTORE_HAVE_SYS_LOG_H)
+check_include_files ("pthread_np.h" PSTORE_HAVE_PTHREAD_NP_H)
 
 check_cxx_source_compiles (
     "#include <cstdlib>

--- a/lib/support/config.hpp.in
+++ b/lib/support/config.hpp.in
@@ -51,7 +51,8 @@
 
 /// Defined if <byteswap.h> is available.
 #cmakedefine PSTORE_HAVE_BYTESWAP_H 1
-
+/// Defined if <pthread_np.h> is available.
+#cmakedefine PSTORE_HAVE_PTHREAD_NP_H  1
 /// Defined if <sys/endian.h> is available.
 #cmakedefine PSTORE_HAVE_SYS_ENDIAN_H 1
 /// Defined if <sys/syscall.h> is available.


### PR DESCRIPTION
You can see the warning in one of the recent CI builds [here](https://github.com/SNSystems/pstore/runs/3101763525?check_suite_focus=true) (expand the build step and then search for “warning” in the log) on macOS or [here](https://github.com/SNSystems/pstore/runs/3101763784?check_suite_focus=true) on Linux.

Use the configuration stage to discover whether <pthread_np.h> is available rather than hard-wiring it for FreeBSD. In general I’m trying to use the configure stage for this sort of thing whenever possible rather than hard-coding it.