### PR TITLE
Add PSTORE_WERROR to optionally enable compiler warnings as errors.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,6 +116,7 @@ jobs:
                         -G "${{ matrix.generator }}"                 \
                         -D PSTORE_EXAMPLES=Yes                       \
                         -D PSTORE_NOISY_UNIT_TESTS=Yes               \
+                        -D PSTORE_WERROR=Yes                         \
                         -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} \
                         ${{ matrix.cxx_compiler }}                   \
                         ${{ matrix.options }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ option (PSTORE_COVERAGE "Enable generation of coverage reports.")
 option (PSTORE_DISABLE_UINT128_T "Disable support for __uint128_t")
 option (PSTORE_CLANG_TIDY_ENABLED "Enable generation of clang-tidy targets")
 option (PSTORE_NOISY_UNIT_TESTS "Produce complete ('noisy') output from the unit test executables")
+option (PSTORE_WERROR "Compiler warnings are errors")
 
 # The name of the vacuum (GC) executable.
 set (PSTORE_VACUUM_TOOL_NAME "pstore-vacuumd")

--- a/cmake/add_pstore.cmake
+++ b/cmake/add_pstore.cmake
@@ -85,7 +85,12 @@ function (pstore_enable_warnings)
             list (APPEND options -Werror)
         endif ()
     elseif (MSVC)
-        set (options -W4)
+        # Enable W4 but disable:
+        # 4324: structure was padded due to alignment specifier
+        set (options
+            -W4
+            -wd4324
+        )
         if (PSTORE_WERROR)
             list (APPEND options /WX)
         endif ()

--- a/cmake/add_pstore.cmake
+++ b/cmake/add_pstore.cmake
@@ -72,14 +72,23 @@ function (pstore_enable_warnings)
                 -Wno-used-but-marked-unused
             )
         endif ()
+        if (PSTORE_WERROR)
+            list (APPEND options -Werror)
+        endif ()
     elseif (CMAKE_COMPILER_IS_GNUCXX)
         set (options
             -Wall
             -Wextra
             -pedantic
         )
+        if (PSTORE_WERROR)
+            list (APPEND options -Werror)
+        endif ()
     elseif (MSVC)
         set (options -W4)
+        if (PSTORE_WERROR)
+            list (APPEND options /WX)
+        endif ()
     endif ()
 
     target_compile_options (${arg_TARGET} PRIVATE ${options})

--- a/lib/os/logging.cpp
+++ b/lib/os/logging.cpp
@@ -244,8 +244,9 @@ namespace {
     syslog_logger::syslog_logger (std::string const & ident, int const facility)
             : facility_{facility} {
 
-        std::strncpy (ident_.data (), ident.c_str (), sizeof (ident_));
-        ident_[ident_.size () - 1] = '\0';
+        auto const size = ident_.size () - 1U;
+        std::strncpy (ident_.data (), ident.c_str (), size);
+        ident_[size] = '\0';
 
         openlog (ident_.data (), LOG_PID, facility_);
     }

--- a/unittests/adt/test_chunked_sequence.cpp
+++ b/unittests/adt/test_chunked_sequence.cpp
@@ -340,18 +340,21 @@ TEST (ChunkedVectorResize, ThreeElementsDownToZero) {
 
 TEST (ChunkedVectorResize, ThreeElementsDownToOne) {
     pstore::chunked_sequence<int, 3U> cv;
+    using difference_type = std::iterator_traits<decltype (cv)::iterator>::difference_type;
     {
         constexpr auto size1 = std::size_t{3};
         cv.resize (size1);
         EXPECT_EQ (cv.size (), size1);
-        EXPECT_EQ (std::distance (std::begin (cv), std::end (cv)), size1);
+        EXPECT_EQ (std::distance (std::begin (cv), std::end (cv)),
+                   static_cast<difference_type> (size1));
         EXPECT_TRUE (std::all_of (std::begin (cv), std::end (cv), [] (int x) { return x == 0; }));
     }
     {
         constexpr auto size2 = std::size_t{1};
         cv.resize (size2);
         EXPECT_EQ (cv.size (), size2);
-        EXPECT_EQ (std::distance (std::begin (cv), std::end (cv)), size2);
+        EXPECT_EQ (std::distance (std::begin (cv), std::end (cv)),
+                   static_cast<difference_type> (size2));
         EXPECT_TRUE (std::all_of (std::begin (cv), std::end (cv), [] (int x) { return x == 0; }));
     }
 }


### PR DESCRIPTION
Warnings-As-Errors is disabled by default but enabled in all the CI builds. The aim is to avoid warnings creeping into the build that we then don’t notice for a while. It has happened a few times (e.g. commit [0d08bbf](https://github.com/SNSystems/pstore/commit/0d08bbff2f52e704ba0beaaac53d2b76f110a6b5)!)