### PR TITLE
Rework index_pointer to make members private and eliminate duplication

### DIFF
--- a/include/pstore/core/diff.hpp
+++ b/include/pstore/core/diff.hpp
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+/// \file diff.hpp
+/// \brief Comparing the contents of an index between two transactions.
 #ifndef PSTORE_CORE_DIFF_HPP
 #define PSTORE_CORE_DIFF_HPP
 
@@ -25,6 +27,7 @@ namespace pstore {
         template <typename Index>
         class traverser {
             using index_pointer = index::details::index_pointer;
+            using internal_node = index::details::internal_node;
 
         public:
             /// \param db  The owning database instance.
@@ -66,7 +69,7 @@ namespace pstore {
 
             bool is_new (index_pointer const node) const noexcept {
                 return node.is_heap () ||
-                       node.untag_internal_address ().to_address () >= threshold_;
+                       node.untag_address<internal_node> ().to_address () >= threshold_;
             }
 
             database const & db_;
@@ -96,7 +99,7 @@ namespace pstore {
                 // If this leaf is not in the "old" byte range then add it to the output
                 // collection.
                 if (this->is_new (node)) {
-                    *out = node.addr;
+                    *out = node.to_address ();
                     ++out;
                 }
                 return out;

--- a/include/pstore/core/hamt_map_types.hpp
+++ b/include/pstore/core/hamt_map_types.hpp
@@ -130,7 +130,7 @@ namespace pstore {
             /// The type information (whether the record points to either an internal or linear
             /// node) is carried externally.
             union index_pointer {
-                constexpr index_pointer () noexcept
+                index_pointer () noexcept
                         : internal_{nullptr} {
 
                     // A belt-and-braces runtime check for cases where pop_count() can't be
@@ -263,7 +263,7 @@ namespace pstore {
             /// \brief A class used to keep the pointer to parent node and the child slot.
             class parent_type {
             public:
-                constexpr parent_type () noexcept = default;
+                parent_type () noexcept = default;
 
                 /// Constructs a parent type object.
                 /// \param idx  The pointer to either the parent node or a leaf node.

--- a/tools/index_structure/index_structure.cpp
+++ b/tools/index_structure/index_structure.cpp
@@ -114,7 +114,7 @@ namespace {
                                    std::ostream & os, index_pointer node, unsigned shifts) {
         PSTORE_ASSERT (!node.is_heap ());
         auto const this_id =
-            node_type_name<NodeType>::name + std::to_string (node.addr.absolute ());
+            node_type_name<NodeType>::name + std::to_string (node.to_address ().absolute ());
 
         std::shared_ptr<void const> store_ptr;
         NodeType const * ptr = nullptr;
@@ -134,7 +134,7 @@ namespace {
                       index_pointer node, unsigned shifts) {
         if (node.is_leaf ()) {
             PSTORE_ASSERT (node.is_address ());
-            return dump_leaf (db, index, os, node.addr);
+            return dump_leaf (db, index, os, node.to_address ());
         }
         return depth_is_internal_node (shifts)
                    ? dump_intermediate<internal_node> (db, index, os, node, shifts)


### PR DESCRIPTION
`untag_internal_address()` and `untag_linear_address()` had identical implementations, so become `untag_address<>`.
`tag_node<>` and `untag_node<>` become `tag<>` and `untag<>` respectively (the ”node” is redundant). `tag<>` can be private. Added validatation of template types.

Replace `crude_pop_count()` with a constexpr recursive implementation which eliminates the limits of the previous version. Validate the result against `bit_count::pop_count()` with static (where the compiler allows) and dynamic assertions.

Add additional assertions to validate the state of the index_pointer.

With this change, I have an eye on future work to eliminate the bloat from indexes shown in issue #104.