### PR TITLE
Reorder the linkage values so that static linkages are first.

### DIFF
--- a/include/pstore/core/file_header.hpp
+++ b/include/pstore/core/file_header.hpp
@@ -94,7 +94,7 @@ namespace pstore {
         std::array<std::uint16_t, 2> const & version () const noexcept { return a.version; }
 
         static constexpr std::uint16_t major_version = 1;
-        static constexpr std::uint16_t minor_version = 12;
+        static constexpr std::uint16_t minor_version = 13;
 
         static std::array<std::uint8_t, 4> const file_signature1;
         static std::uint32_t const file_signature2 = 0x0507FFFF;

--- a/include/pstore/mcrepo/compilation.hpp
+++ b/include/pstore/mcrepo/compilation.hpp
@@ -27,12 +27,14 @@
 namespace pstore {
     namespace repo {
 
+// Note that we place the values that represent internal linkages first to simplify the decision
+// about whether a symbol has static or global linkage.
 #define PSTORE_REPO_LINKAGES                                                                       \
+    X (internal_no_symbol)                                                                         \
+    X (internal)                                                                                   \
     X (append)                                                                                     \
     X (common)                                                                                     \
     X (external)                                                                                   \
-    X (internal_no_symbol)                                                                         \
-    X (internal)                                                                                   \
     X (link_once_any)                                                                              \
     X (link_once_odr)                                                                              \
     X (weak_any)                                                                                   \


### PR DESCRIPTION
Whilst performing layout, rld checks whether every symbol has static or global linkage. There are two motivations:

- The ELF specification requires that static symbols always appear before global symbols in the symbol table.
- rld needs to ensure that the symbol table is always in the same order, regardless of how its threads are scheduled. This means that the list append must be performed by the layout thread.

By placing the static linkage types first, the check is simply whether the linkage value is 0 or 1.

Reordering the enum changes the on-disk representation, so bump the minor version number.