### PR TITLE
Add database::getrou() functions.

### DIFF
--- a/include/pstore/mcrepo/fragment.hpp
+++ b/include/pstore/mcrepo/fragment.hpp
@@ -141,8 +141,8 @@ namespace pstore {
             /// \param db  The database from which the fragment is to be read.
             /// \param location  The address and size of the fragment data.
             /// \returns  A unique pointer to the fragment instance.
-            static database::unique_pointer<fragment const>
-            loadu (pstore::database const & db, pstore::extent<fragment> const & location);
+            static unique_pointer<fragment const> loadu (pstore::database const & db,
+                                                         pstore::extent<fragment> const & location);
 
             /// Provides a pointer to an individual fragment instance given a transaction and an
             /// extent describing its address and size.

--- a/include/pstore/mcrepo/fragment.hpp
+++ b/include/pstore/mcrepo/fragment.hpp
@@ -126,14 +126,23 @@ namespace pstore {
             static pstore::extent<fragment> alloc (Transaction & transaction, Iterator first,
                                                    Iterator last);
 
-            /// Provides a pointer to an individual fragment instance given a database and a extent
-            /// describing its address and size.
+            /// Returns a shared pointer to a read-only individual fragment instance given a
+            /// database instance and a extent describing its address and size.
             ///
             /// \param db  The database from which the fragment is to be read.
             /// \param location  The address and size of the fragment data.
-            /// \returns  A pointer to the fragment instance.
+            /// \returns  A shared pointer to the fragment instance.
             static std::shared_ptr<fragment const> load (database const & db,
                                                          extent<fragment> const & location);
+
+            /// Returns a unique pointer to a read-only individual fragment instance given a
+            /// database instance and a extent describing its address and size.
+            ///
+            /// \param db  The database from which the fragment is to be read.
+            /// \param location  The address and size of the fragment data.
+            /// \returns  A unique pointer to the fragment instance.
+            static database::unique_pointer<fragment const>
+            loadu (pstore::database const & db, pstore::extent<fragment> const & location);
 
             /// Provides a pointer to an individual fragment instance given a transaction and an
             /// extent describing its address and size.
@@ -223,8 +232,8 @@ namespace pstore {
                 padding1_ = 0; // assignment to silence an "unused" warning from clang.
             }
 
-            /// Returns pointer to an individual fragment instance given a function which can yield
-            /// it given the object's extent.
+            /// Returns a pointer to an individual fragment instance given a function which can
+            /// yield it given the object's extent.
             template <typename ReturnType, typename GetOp>
             static ReturnType load_impl (extent<fragment> const & location, GetOp get);
 

--- a/lib/mcrepo/fragment.cpp
+++ b/lib/mcrepo/fragment.cpp
@@ -99,9 +99,9 @@ std::shared_ptr<fragment const> fragment::load (pstore::database const & db,
 
 // loadu
 // ~~~~~
-pstore::database::unique_pointer<fragment const>
-fragment::loadu (pstore::database const & db, pstore::extent<fragment> const & location) {
-    return load_impl<database::unique_pointer<fragment const>> (
+pstore::unique_pointer<fragment const> fragment::loadu (pstore::database const & db,
+                                                        pstore::extent<fragment> const & location) {
+    return load_impl<unique_pointer<fragment const>> (
         location, [&db] (extent<fragment> const & x) { return db.getrou (x); });
 }
 

--- a/lib/mcrepo/fragment.cpp
+++ b/lib/mcrepo/fragment.cpp
@@ -97,7 +97,15 @@ std::shared_ptr<fragment const> fragment::load (pstore::database const & db,
         location, [&db] (extent<fragment> const & x) { return db.getro (x); });
 }
 
-// section_offset_is_valid [static]
+// loadu
+// ~~~~~
+pstore::database::unique_pointer<fragment const>
+fragment::loadu (pstore::database const & db, pstore::extent<fragment> const & location) {
+    return load_impl<database::unique_pointer<fragment const>> (
+        location, [&db] (extent<fragment> const & x) { return db.getrou (x); });
+}
+
+// section offset is valid [static]
 // ~~~~~~~~~~~~~~~~~~~~~~~
 template <section_kind Key, typename InstanceType>
 std::uint64_t
@@ -113,7 +121,7 @@ fragment::section_offset_is_valid (fragment const & f, pstore::extent<fragment> 
                : offset + size;
 }
 
-// fragment_appears_valid [static]
+// fragment appears valid [static]
 // ~~~~~~~~~~~~~~~~~~~~~~
 bool fragment::fragment_appears_valid (fragment const & f, pstore::extent<fragment> const & fext) {
 #if PSTORE_SIGNATURE_CHECKS_ENABLED
@@ -159,7 +167,7 @@ bool fragment::fragment_appears_valid (fragment const & f, pstore::extent<fragme
     return true;
 }
 
-// size_bytes
+// size bytes
 // ~~~~~~~~~~
 std::size_t fragment::size_bytes () const {
     if (arr_.size () == 0) {
@@ -174,21 +182,21 @@ std::size_t fragment::size_bytes () const {
 }
 
 
-// section_align
+// section align
 // ~~~~~~~~~~~~~
 unsigned pstore::repo::section_align (fragment const & f, section_kind const kind) {
     dispatcher_buffer buffer;
     return make_dispatcher (f, kind, &buffer)->align ();
 }
 
-// section_size
+// section size
 // ~~~~~~~~~~~~~
 std::size_t pstore::repo::section_size (fragment const & f, section_kind const kind) {
     dispatcher_buffer buffer;
     return make_dispatcher (f, kind, &buffer)->size ();
 }
 
-// section_ifixups
+// section ifixups
 // ~~~~~~~~~~~~~~~
 container<internal_fixup> pstore::repo::section_ifixups (fragment const & f,
                                                          section_kind const kind) {
@@ -196,7 +204,7 @@ container<internal_fixup> pstore::repo::section_ifixups (fragment const & f,
     return make_dispatcher (f, kind, &buffer)->ifixups ();
 }
 
-// section_xfixups
+// section xfixups
 // ~~~~~~~~~~~~~~~
 container<external_fixup> pstore::repo::section_xfixups (fragment const & f,
                                                          section_kind const kind) {
@@ -204,7 +212,7 @@ container<external_fixup> pstore::repo::section_xfixups (fragment const & f,
     return make_dispatcher (f, kind, &buffer)->xfixups ();
 }
 
-// section_data
+// section data
 // ~~~~~~~~~~~~
 container<std::uint8_t> pstore::repo::section_value (fragment const & f, section_kind const kind) {
     dispatcher_buffer buffer;

--- a/unittests/core/test_database.cpp
+++ b/unittests/core/test_database.cpp
@@ -187,7 +187,7 @@ TEST_F (Database, Read16Bytes) {
     {
         // Get a read-only unique-pointer to the memory and ensure that its contents are the values
         // we just put there.
-        pstore::database::unique_pointer<std::uint8_t const> u =
+        pstore::unique_pointer<std::uint8_t const> u =
             db.getrou (pstore::typed_address<std::uint8_t> (addr), size);
         auto * const up = u.get ();
         std::vector<std::uint8_t> const u_actuals{up, up + size};


### PR DESCRIPTION
Add a family of database APIs which return read-only `unique_ptr<>`-managed memory in the store. These mirror the existing getro() functions which return `std::shared_ptr<>`. The idea is that we avoid the costly atomic reference counting operations of the `shared_ptr<>` versions when we want the best possible performance, and don’t need this sort of memory-management help, esp. in rld.