### PR TITLE
Create DebugLocSection as a dummy section.

### DIFF
--- a/include/pstore/mcrepo/section.hpp
+++ b/include/pstore/mcrepo/section.hpp
@@ -43,6 +43,7 @@ namespace pstore {
     X (thread_data)                                                                                \
     X (thread_bss)                                                                                 \
     X (debug_line)                                                                                 \
+    X (debug_loc)                                                                                  \
     X (debug_string)                                                                               \
     X (debug_ranges)                                                                               \
     X (linked_definitions)


### PR DESCRIPTION
Create DebugLocSection as a dummy section which enable the assembler to have a "default" section to avoid an assertion failure.

Fix for https://github.com/SNSystems/llvm-project-prepo/issues/175.