### PR TITLE
Repair the GH CI action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
 
                     - name: Windows-latest/MSVC/Release
                       build_type: Release
-                      generator: Visual Studio 16 2019
+                      generator: Visual Studio 17 2022
                       os: windows-latest
 
         name: ${{ matrix.name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,16 +80,22 @@ jobs:
                       os: ubuntu-latest
 
 
-                    - name: Windows-latest/MSVC/Debug
+                    - name: Windows-latest/VS2022/Debug
                       build_type: Debug
                       generator: Visual Studio 17 2022
                       options: '-DPSTORE_ALWAYS_SPANNING=Yes'
                       os: windows-latest
 
-                    - name: Windows-latest/MSVC/Release
+                    - name: Windows-latest/VS2022/Release
                       build_type: Release
                       generator: Visual Studio 17 2022
                       os: windows-latest
+
+                    - name: Windows-2016/VS2019/Debug
+                      build_type: Debug
+                      generator: Visual Studio 16 2019
+                      options: '-DPSTORE_ALWAYS_SPANNING=Yes'
+                      os: Windows-2016
 
         name: ${{ matrix.name }}
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,7 @@ jobs:
 
             - name: Install Dependencies (Linux)
               if: matrix.os == 'ubuntu-latest' && matrix.apt_install != ''
-              run: sudo apt-get install -y ${{ matrix.apt_install }}
+              run: sudo apt-get update && sudo apt-get install -y ${{ matrix.apt_install }}
 
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,11 +91,11 @@ jobs:
                       generator: Visual Studio 17 2022
                       os: windows-latest
 
-                    - name: Windows-2016/VS2019/Debug
+                    - name: Windows-2019/VS2019/Debug
                       build_type: Debug
                       generator: Visual Studio 16 2019
                       options: '-DPSTORE_ALWAYS_SPANNING=Yes'
-                      os: Windows-2016
+                      os: Windows-2019
 
         name: ${{ matrix.name }}
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,8 @@ jobs:
         strategy:
             matrix:
                 include:
+                    # macOS builds
+                    # ~~~~~~~~~~~~
                     - name: macOS-latest/Xcode/Debug
                       build_type: Debug
                       generator: Xcode
@@ -18,6 +20,8 @@ jobs:
                       os: macos-latest
 
 
+                    # Ubuntu builds
+                    # ~~~~~~~~~~~~~
                     - name: Ubuntu-latest/gcc-7.5/Debug
                       apt_install: g++-7
                       build_type: Debug
@@ -79,7 +83,8 @@ jobs:
                       options: '-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold'
                       os: ubuntu-latest
 
-
+                    # Windows builds
+                    # ~~~~~~~~~~~~~~
                     - name: Windows-latest/VS2022/Debug
                       build_type: Debug
                       generator: Visual Studio 17 2022
@@ -95,6 +100,11 @@ jobs:
                       build_type: Debug
                       generator: Visual Studio 16 2019
                       options: '-DPSTORE_ALWAYS_SPANNING=Yes'
+                      os: Windows-2019
+
+                    - name: Windows-2019/VS2019/Release
+                      build_type: Release
+                      generator: Visual Studio 16 2019
                       os: Windows-2019
 
         name: ${{ matrix.name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
 
                     - name: Windows-latest/MSVC/Debug
                       build_type: Debug
-                      generator: Visual Studio 16 2019
+                      generator: Visual Studio 17 2022
                       options: '-DPSTORE_ALWAYS_SPANNING=Yes'
                       os: windows-latest
 

--- a/lib/core/uuid.cpp
+++ b/lib/core/uuid.cpp
@@ -20,6 +20,7 @@
 #include "pstore/core/uuid.hpp"
 
 #include <iomanip>
+#include <mutex>
 #include <ostream>
 
 #include "pstore/support/error.hpp"
@@ -69,12 +70,12 @@ namespace pstore {
     // (ctor)
     // ~~~~~~
     uuid::uuid () {
-        static random_generator<unsigned> random;
-        auto const generator = [] () {
-            constexpr auto max = std::numeric_limits<std::uint8_t>::max ();
-            return static_cast<std::uint8_t> (random.get (max));
-        };
-        std::generate (std::begin (data_), std::end (data_), generator);
+        {
+            static std::mutex mutex;
+            static random_generator<std::uint8_t> random;
+            std::lock_guard<std::mutex> _{mutex};
+            std::generate (std::begin (data_), std::end (data_), [] () { return random.get (); });
+        }
 
         // Set variant: must be 0b10xxxxxx
         data_[variant_octet] &= 0b10111111;

--- a/lib/support/utf_win32.cpp
+++ b/lib/support/utf_win32.cpp
@@ -95,6 +95,7 @@ namespace {
                 output->data (),             // output buffer
                 length_as_int (output_size)) // size (in code units) of the output buffer
         );
+        (void) wchars_written;
         PSTORE_ASSERT (wchars_written <= output_size * sizeof (output_char_type));
         PSTORE_ASSERT (wchars_written == from_8_to_16_traits::output_size (wstr, wstr_length));
     }
@@ -144,6 +145,7 @@ namespace {
                                    nullptr, // missing character (must be NULL for UTF8)
                                    nullptr) // missing character was used? (must be NULL for UTF8)
         );
+        (void) bytes_written;
         PSTORE_ASSERT (bytes_written <= output_size);
         PSTORE_ASSERT (bytes_written == from_16_to_8_traits::output_size (wstr, wstr_length));
     }


### PR DESCRIPTION
1. The Windows-latest image changed to include a more recent edition of Visual Studio. Update the cmake generator name accordingly.
2. Add a second pair of Windows builds to retain the older VS version.
3. Need to do a apt-get update before install on the Ubuntu builds to avoid a failure trying to install Valgrind.
4. The latest version of VS introduced a couple of new warnings (we compile with warnings as errors).